### PR TITLE
Added Keyboard Shortcuts

### DIFF
--- a/resource/ui/charinfopanel.res
+++ b/resource/ui/charinfopanel.res
@@ -160,7 +160,7 @@
 		"visible"		"1"
 		"enabled"		"1"
 		"tabPosition"	"0"
-		"labelText"		"Back"
+		"labelText"		"Back (&Q)"
 		"font"			"FontBold14"
 		"textAlignment"	"center"
 		"dulltext"		"0"

--- a/resource/ui/classselection.res
+++ b/resource/ui/classselection.res
@@ -453,7 +453,7 @@
 		"visible"		"1"
 		"enabled"		"1"
 		"tabPosition"	"0"
-		"labelText"		"&C  Cancel"
+		"labelText"		"&Q  Cancel"
 		"textAlignment"	"west"
 		"Command"		"vguicancel"
 		"font"			"FontRegular12"

--- a/resource/ui/econ/store/v2/storepanel.res
+++ b/resource/ui/econ/store/v2/storepanel.res
@@ -159,7 +159,7 @@
 		"visible"			"1"
 		"enabled"			"1"
 		"tabPosition"		"0"
-		"labelText"			"Exit Store"
+		"labelText"			"Exit Store (&Q)"
 		"font"				"FontBold14"
 		"textAlignment"		"center"
 		"dulltext"			"0"

--- a/resource/ui/itemselectionpanel.res
+++ b/resource/ui/itemselectionpanel.res
@@ -234,7 +234,7 @@
 		"visible"		"1"
 		"enabled"		"1"
 		"tabPosition"	"0"
-		"labelText"		"#Cancel"
+		"labelText"		"&Q #Cancel"
 		"font"			"HudFontSmallBold"
 		"textAlignment"	"center"
 		"dulltext"		"0"

--- a/resource/ui/replaybrowser/mainpanel.res
+++ b/resource/ui/replaybrowser/mainpanel.res
@@ -152,7 +152,7 @@
 		"visible"		"1"
 		"enabled"		"1"
 		"tabPosition"	"0"
-		"labelText"		"Back"
+		"labelText"		"Back (&Q)"
 		"font"			"FontBold14"
 		"textAlignment"	"center"
 		"dulltext"		"0"


### PR DESCRIPTION
I really liked how quickly I could navigate through the character selection/loadout and inventory in the rayshud, using the back hotkey. So I thought that it would be great to have same functionality in the flawhud.