### PR TITLE
Keyboard Shortcut Hot-Fix

### DIFF
--- a/resource/ui/itemselectionpanel.res
+++ b/resource/ui/itemselectionpanel.res
@@ -234,7 +234,7 @@
 		"visible"		"1"
 		"enabled"		"1"
 		"tabPosition"	"0"
-		"labelText"		"&Q #Cancel"
+		"labelText"		"#Cancel"
 		"font"			"HudFontSmallBold"
 		"textAlignment"	"center"
 		"dulltext"		"0"


### PR DESCRIPTION
Turned out that hotkey for 'CancelButton' was excessive and caused problems in the loadout menu: whenever player tried to close item selection without picking a new item or weapon, selected slot were switched to the stock.