### PR TITLE
Restored shadow label in the Medigun Panel

### DIFF
--- a/resource/ui/medigunpanel.res
+++ b/resource/ui/medigunpanel.res
@@ -305,7 +305,7 @@
 		"autoResize"	"1"
 		"labelText"		"#TF_Weapon_Medigun"
 		"visible"		"0"
-		"enabled"		"1"
+		"enabled"		"0"
 		"tabPosition"	"0"
 		"textAlignment"	"west"
 		"dulltext"		"0"


### PR DESCRIPTION
I do not understand basically anything about HUD making, but I saw here that the "visible" had the value of "0", so why "enabled" does not have its value set to "0" too?