### PR TITLE
hudlayout.res (Transparent Viewmodels)

### DIFF
--- a/scripts/hudlayout.res
+++ b/scripts/hudlayout.res
@@ -39,7 +39,7 @@
 		"tall"				"480"
 		"visible"			"0"		// Change to "1" to enable
 		"enabled"			"0"		// Change to "1" to enable
-		"image"				"replay/thumbnails/transparency"
+		"image"				"replay/thumbnails/transparent"
 		"scaleImage"		"1"
 	}
 	//--------------------------------------------------------------

--- a/scripts/hudlayout.res
+++ b/scripts/hudlayout.res
@@ -28,7 +28,7 @@
 	//--------------------------------------------------------------
 	// Set visible/enabled to 1 to use.
 	//--------------------------------------------------------------
-	"TransparentViewmodel"
+	TransparentViewmodel
 	{
 		"ControlName"		"ImagePanel"
 		"fieldName"			"TransparentViewmodel"
@@ -39,7 +39,7 @@
 		"tall"				"480"
 		"visible"			"0"		// Change to "1" to enable
 		"enabled"			"0"		// Change to "1" to enable
-		"image"				"replay/thumbnails/transparent"
+		"image"				"replay/thumbnails/REFRACTnormal_transparent"
 		"scaleImage"		"1"
 	}
 	//--------------------------------------------------------------

--- a/scripts/hudlayout.res
+++ b/scripts/hudlayout.res
@@ -39,7 +39,7 @@
 		"tall"				"480"
 		"visible"			"0"		// Change to "1" to enable
 		"enabled"			"0"		// Change to "1" to enable
-		"image"				"replay/thumbnails/REFRACTnormal_transparent"
+		"image"				"replay/thumbnails/transparency"
 		"scaleImage"		"1"
 	}
 	//--------------------------------------------------------------


### PR DESCRIPTION
Removed the double quotes in the "Transparent Viewmodel" field and changed the "image" directory to correspond to the original file on the TFTV topic.