### PR TITLE
Change color of chat window to better match and fix bug in the class selection

### DIFF
--- a/resource/ui/basechat.res
+++ b/resource/ui/basechat.res
@@ -10,7 +10,8 @@
 		"ypos"					"25"
 		"wide"					"210"
 		"tall"					"100"
-		"PaintBackgroundType"	"0"
+		"PaintBackgroundType"			"0"
+		"bgcolor_override"			"0 0 0 255"
 	}
 
 	ChatInputLine

--- a/resource/ui/classselection.res
+++ b/resource/ui/classselection.res
@@ -355,10 +355,18 @@
 		"keyboardinputenabled"	"0"
 	}
 
+	// I believe Valve hardcoded part of this control for some reason.
+	// Using the same control with a different name fixes it.
 	"random"
 	{
+		"visible"		"0"
+		"enabled"		"0"
+	}
+	
+	"random2"
+	{
 		"ControlName"		"CExButton"
-		"fieldName"			"random"
+		"fieldName"			"random2"
 		"xpos"				"c100"
 		"ypos"				"c77"
 		"zpos"				"6"


### PR DESCRIPTION
* Changed the base color of the chat window to better match the theme. The filters button, controls, and text are still the same as stock HUD but it's progress I guess.
* There was a bug I encountered when the Random class button in the class selection menu. It seems to be due to some hard code in the control itself. Using the same values on what the game considers a different control (Different name) and disabling the before used control seems to do the trick.