### PR TITLE
Corrected formatting inconsistency in hudlayout.res

### DIFF
--- a/scripts/hudlayout.res
+++ b/scripts/hudlayout.res
@@ -46,6 +46,7 @@
 		"drawcolor"			"Crosshair"
 		"Alpha"				"255"
 	}
+	
 	CrosshairPulse
 	{
 		"ControlName"		"CTFImagePanel"
@@ -67,7 +68,7 @@
 	//--------------------------------------------------------------
 	// Set visible/enabled to 1 to use.
 	//--------------------------------------------------------------
-	"TransparentViewmodel"
+	TransparentViewmodel
 	{
 		"ControlName"		"ImagePanel"
 		"fieldName"			"TransparentViewmodel"


### PR DESCRIPTION
- Removed quotation marks around TransparentViewmodels and a new line between Crosshair nodes.