### PR TITLE
remove unnecessary position offsets

### DIFF
--- a/resource/ui/farmageddonhud.res
+++ b/resource/ui/farmageddonhud.res
@@ -6,16 +6,8 @@
     {
          "CarriedImage"
          {
-             "image"                                             "../hud/weedkiller_icon"
+             "image"				"../hud/weedkiller_icon"
          }
-    }
-    "CountdownContainer"
-    {
-        "CountdownImage"
-        {
-            "xpos"            "117"
-            "ypos"            "15"
-        }
     }
     "ScoreContainer"
     {
@@ -23,13 +15,11 @@
          {
              "FlagImageBlue"
              {
-                     "image"                                             "../hud/weedkiller_icon"
-                     "zpos"            "100"
+                     "image"		"../hud/weedkiller_icon"
              }
              "FlagImageRed"
              {
-                     "image"                                             "../hud/weedkiller_icon"
-                     "zpos"            "100"
+                     "image"		"../hud/weedkiller_icon"
              }
          }
     }


### PR DESCRIPTION
I left in some position offsets in the Farmageddon HUD fix. This commit removes them.