### PR TITLE
Revert meter label color change

### DIFF
--- a/resource/scheme/clientscheme_settings.res
+++ b/resource/scheme/clientscheme_settings.res
@@ -88,7 +88,7 @@ Scheme
 		Label.SelectedTextColor					"White"
 		Label.BgColor							"Blank"
 		Label.DisabledFgColor1					"Blank"
-		Label.DisabledFgColor2					"150 150 150 255"
+		Label.DisabledFgColor2					"Black"
 
 		ListPanel.TextColor						"Orange"
 		ListPanel.BgColor						"TransparentBlack"

--- a/resource/ui/huddemomancharge.res
+++ b/resource/ui/huddemomancharge.res
@@ -34,6 +34,7 @@
 		"labelText"			"#TF_Charge"
 		"textAlignment"		"center"
 		"font"				"FontBold10"
+		"fgcolor_override"	"Black"
 
 		"pin_to_sibling"		"ChargeMeter"
 		"pin_corner_to_sibling"	"PIN_TOPRIGHT"

--- a/resource/ui/huditemeffectmeter.res
+++ b/resource/ui/huditemeffectmeter.res
@@ -31,6 +31,7 @@
 		"dulltext"			"0"
 		"brighttext"		"0"
 		"font"				"FontBold10"
+		"fgcolor_override"	"Black"
 	}
 
 	"ItemEffectMeter"


### PR DESCRIPTION
The current color is hard to be seen, and the old color (black) has been on the HUD for so long and I have never seen any complaints about it.

About this current color, I saw only one complaint, which was on Discord (in addition to my complaint, of course).

![image](https://user-images.githubusercontent.com/30274161/138987787-bcad0dc4-502d-4632-ba0e-87ff746369d8.png)
