### PR TITLE
Remove coaching crosshair

### DIFF
--- a/resource/ui/spectatorcoach.res
+++ b/resource/ui/spectatorcoach.res
@@ -82,8 +82,8 @@
 		"zpos"				"-100"
 		"wide"				"16"
 		"tall"				"16"
-		"visible"			"1"
-		"enabled"			"1"
+		"visible"			"0"
+		"enabled"			"0"
 		"image"				"crosshairs/default"
 		"scaleImage"		"1"
 	}


### PR DESCRIPTION
This change prevents two crosshairs from appearing at the same time.