### PR TITLE
Fix for coach crosshair

### DIFF
--- a/resource/ui/spectatorcoach.res
+++ b/resource/ui/spectatorcoach.res
@@ -72,22 +72,7 @@
 		"wide"				"250"
 		"tall"				"120"
 	}
-	
-	"Crosshair"
-	{
-		"ControlName"		"ImagePanel"
-		"fieldName"			"Crosshair"
-		"xpos"				"c-8"
-		"ypos"				"c-8"
-		"zpos"				"-100"
-		"wide"				"16"
-		"tall"				"16"
-		"visible"			"0"
-		"enabled"			"0"
-		"image"				"crosshairs/default"
-		"scaleImage"		"1"
-	}
-	
+
 	"CoachingLabel"
 	{
 		"ControlName"		"CExLabel"

--- a/resource/ui/spectatorcoach.res
+++ b/resource/ui/spectatorcoach.res
@@ -1,5 +1,3 @@
-#base "hudinspectpanel.res"
-
 "Resource/UI/SpectatorCoach.res"
 {
 	"Spectator"


### PR DESCRIPTION
For some reason, the crosshair still appears. Removing the section completely fixes it.

This fixes #198