### PR TITLE
Remove boss progress bar background

### DIFF
--- a/resource/ui/tankstatuspanel.res
+++ b/resource/ui/tankstatuspanel.res
@@ -1,0 +1,10 @@
+"Resource/UI/TankStatusPanel.res"
+{
+	"Background"
+	{
+		"ControlName"		"ScalableImagePanel"
+		"fieldName"			"Background"
+		"xpos"				"-9999"
+		"ypos"				"-9999"
+	}
+}


### PR DESCRIPTION
This PR removes the default TF2 boss progress bar background, making the boss progress bar consistent with the wave progress bar

Current:
![current](https://user-images.githubusercontent.com/43595566/152086532-31cfc7aa-0383-4e2b-8856-362478cf3b7d.png)

New:
![new](https://user-images.githubusercontent.com/43595566/152086552-3ed11f5a-66ab-4692-874f-13694c99797e.png)