### PR TITLE
Fix the Notification Text in the Main Menu

### DIFF
--- a/resource/ui/econ/genericnotificationtoastmainmenu.res
+++ b/resource/ui/econ/genericnotificationtoastmainmenu.res
@@ -1,1 +1,8 @@
 #base "GenericNotificationToast.res"
+"Resource/UI/GenericNotificationToastMainMenu.res"
+{
+    "TextLabel"
+    {
+	    "fgcolor"			"HudBlack"
+    }
+}


### PR DESCRIPTION
Probably the fix of #256 made the text in the Main Menu TanLight even though its background has the same color
![image](https://user-images.githubusercontent.com/47070328/200119641-292dcc53-a74a-4d44-bd30-87ae244a1b27.png)

After changing `genericnotificationtoastmainmenu.res`:
![image](https://user-images.githubusercontent.com/47070328/200119675-88b48b55-5d74-44ec-a04c-d2fee8ecc406.png)
