### PR TITLE
Update tools.res slider values

### DIFF
--- a/resource/tools.res
+++ b/resource/tools.res
@@ -189,8 +189,8 @@
 			"tall"					"20"
 			"leftText"				"70"
 			"rightText"				"90"
-			"minvalue"				"70"
-			"maxvalue"				"90"
+			"minvalue"				"54"
+			"maxvalue"				"70"
 			"cvar_name"				"viewmodel_fov"
 			"allowoutofrange"		"0"
 			
@@ -272,7 +272,7 @@
 			"leftText"				"0.0"
 			"rightText"				"1.0"
 			"minvalue"				"0"
-			"maxvalue"				"100"
+			"maxvalue"				"1"
 			"cvar_name"				"voice_scale"
 			"allowoutofrange"		"0"
 			

--- a/resource/tools.res
+++ b/resource/tools.res
@@ -413,7 +413,7 @@
 			"visible"				"1"
 			"enabled"				"1"
 			"labeltext"				"#FH_viewmodel_min"
-			"command"				"engine toggle tf_use_min_viewmodels 1 0"
+			"command"				"engine toggle tf_use_min_viewmodels"
 			"actionsignallevel"		"2"
 			"font"					"FontBold12"
 			"textAlignment"			"center"

--- a/resource/tools.res
+++ b/resource/tools.res
@@ -231,7 +231,7 @@
 			"leftText"				"0.0"
 			"rightText"				"1.0"
 			"minvalue"				"0"
-			"maxvalue"				"100"
+			"maxvalue"				"1"
 			"cvar_name"				"volume"
 			"allowoutofrange"		"0"
 			


### PR DESCRIPTION
Viewmodel - min. value 54 and max. value 70. These are the values used by Valve in the advanced options dialog.

Voice - min. value 0 and max. value 1. Anything above 1 distorts the voice of other players.

I also removed unnecessary values from the min. viewmodel toggle.

I also changed the max. value for the volume cvar to 1 instead of 100.