### PR TITLE
Fixed overlapping of players' time with scroll bar in vote menu

### DIFF
--- a/resource/ui/votehud.res
+++ b/resource/ui/votehud.res
@@ -608,7 +608,7 @@
 			"xpos"				"190"
 			"ypos"				"38"
 			"zpos"				"2"
-			"wide"				"200"
+			"wide"				"227"
 			"wide_minmode"		"0"
 			"tall"				"200"
 			"pinCorner"			"0"


### PR DESCRIPTION
![20230825193949_1](https://github.com/CriticalFlaw/flawhud/assets/117596825/35c4f8a3-f544-4c17-a08f-14352d2c154a)
The scroll bar is still present, it's just now small.
![20230825190251_1](https://github.com/CriticalFlaw/flawhud/assets/117596825/a66040ea-a96a-4503-a307-a44704c61717)