### PR TITLE
Fixed hard-coded color for vote setup dialog

### DIFF
--- a/resource/ui/votehud.res
+++ b/resource/ui/votehud.res
@@ -554,7 +554,7 @@
 		"tabPosition"			"0"
 		"settitlebarvisible"	"0"
 		"paintborder"			"0"
-		"bgcolor_override"		"27 27 27 255"
+		"bgcolor_override"		"HudBlack"
 		"PaintBackground"		"1"
 		"PaintBackgroundType"	"2"
 


### PR DESCRIPTION
Closes #378 
The vote setup dialog had a hard-coded color override with a 255 alpha component, hence it became non-transparent after opening the second time. I changed it to the more common "HudBlack" color (16 16 16 185).