### PR TITLE
Training mode fixes

### DIFF
--- a/resource/ui/hudtraining.res
+++ b/resource/ui/hudtraining.res
@@ -74,7 +74,7 @@
 		"wrap"				"1"
 		"labelText"			""
 		"textAlignment"		"North"
-		"font"				"FontRegular12"
+		"font"				"DefaultSmall"
 	}
 
 	"PressSpacebarToContinue"

--- a/resource/ui/intromenu.res
+++ b/resource/ui/intromenu.res
@@ -79,7 +79,7 @@
 	{
 		"ControlName"		"CExButton"
 		"fieldName"			"Continue"
-		"xpos"				"c-100"
+		"xpos"				"r225"
 		"ypos"				"r50"
 		"zpos"				"2"
 		"wide"				"200"
@@ -130,7 +130,7 @@
 	{
 		"ControlName"		"CExButton"
 		"fieldName"			"ReplayVideo"
-		"xpos"				"c-100"
+		"xpos"				"30"
 		"ypos"				"r50"
 		"zpos"				"2"
 		"wide"				"200"


### PR DESCRIPTION
Fixed overlapping of buttons
before
![20230916214249_1](https://github.com/CriticalFlaw/flawhud/assets/117596825/73fac1ce-2670-47fb-a09c-6bc3501b93f0)
after
![20230916210914_1](https://github.com/CriticalFlaw/flawhud/assets/117596825/093b9278-06f1-4674-8db9-9b21f38e66b8)

Fixed MsgLabel cutoff
before
![20230916214326_1](https://github.com/CriticalFlaw/flawhud/assets/117596825/747201ff-7bc7-4273-841e-be9d99a64fd6)
after
![20230916210948_1](https://github.com/CriticalFlaw/flawhud/assets/117596825/77a09010-47a6-431d-81a0-66c8a5343a6b)