### PR TITLE
use new smissmas 2023 background image

### DIFF
--- a/resource/ui/mainmenuoverride.res
+++ b/resource/ui/mainmenuoverride.res
@@ -201,7 +201,7 @@
 		}
 		"if_christmas"
 		{
-			"image"		"../console/background_xmas2020_widescreen"
+			"image"		"../console/background_xmas2023_widescreen"
 		}
 	}
 


### PR DESCRIPTION
In the Smissmas 2023 update, there was a new main menu background image added to the game (undocumented). This simple one-line change replaces the previous 2020 background image with the new 2023 one.

https://wiki.teamfortress.com/wiki/December_7,_2023_Patch
https://www.teamfortress.com/post.php?id=213565