### PR TITLE
Change mastercomfig.com to comfig.app

### DIFF
--- a/resource/links.res
+++ b/resource/links.res
@@ -144,7 +144,7 @@
 			"textAlignment"			"center"
 			"fgcolor_override"		"HudWhite"
 			"proportionaltoparent"	"1"
-			"urlText"				"https://mastercomfig.com/quickplay/"
+			"urlText"				"https://comfig.app/quickplay/"
 		}
 
 		"ComfigLogo"


### PR DESCRIPTION
# Main body 
[https://mastercomfig.com](https://mastercomfig.com), "will be replaced by [https://comfig.app](https://comfig.app) soon," according to mastercoms in her discord server [here](https://discord.com/channels/389089828249010188/928764364490686564/1251242739614617661). Therefore, the link in flawhud should be set to [https://comfig.app](https://comfig.app) instead of [https://mastercomfig.com](https://mastercomfig.com).