### PR TITLE
Workaround for not being able to vote for a map

### DIFF
--- a/resource/ui/matchmakingdashboard.res
+++ b/resource/ui/matchmakingdashboard.res
@@ -689,5 +689,101 @@
 			"armedFgColor_override" 		"CreditsGreen"
 			"depressedFgColor_override" 	"CreditsGreen"
 		}
+
+		"Map1"
+		{
+			"ControlName"			"Button"
+			"fieldName"			"Map1"
+			"xpos"				"1"
+			"zpos"				"100"
+			"wide"				"30"
+			"tall"				"f6"
+			"visible"			"1"
+			"font"				"HudFontSmallBold"
+			"textAlignment"			"center"
+			"command"			"engine next_map_vote 0"
+			"proportionaltoparent"		"1"
+			"labeltext"			"1"
+			"actionsignallevel"		"3"
+			"roundedcorners"		"0"
+			"textinsety"			"5"
+			"use_proportional_insets"	"1"
+			"paintbackground"		"0"
+			
+			"FgColor"			"TanLight"
+			"defaultFgColor_override"	"TanLight"
+			"armedFgColor_override"		"170 221 183 155"
+			"depressedFgColor_override"	"170 221 183 155"
+			
+			"sound_depressed"		"UI/buttonclick.wav"
+			"sound_released"		"UI/buttonclickrelease.wav"
+			
+			"pin_to_sibling"		"Map2"
+			"pin_corner_to_sibling"		"1"
+		}
+
+		"Map2"
+		{
+			"ControlName"			"Button"
+			"fieldName"			"Map2"
+			"xpos"				"1"
+			"zpos"				"100"
+			"wide"				"30"
+			"tall"				"f6"
+			"visible"			"1"
+			"font"				"HudFontSmallBold"
+			"textAlignment"			"center"
+			"command"			"engine next_map_vote 1"
+			"proportionaltoparent"		"1"
+			"labeltext"			"2"
+			"actionsignallevel"		"3"
+			"roundedcorners"		"0"
+			"textinsety"			"5"
+			"use_proportional_insets"	"1"
+			"paintbackground"		"0"
+			
+			"FgColor"			"TanLight"
+			"defaultFgColor_override"	"TanLight"
+			"armedFgColor_override"		"170 221 183 155"
+			"depressedFgColor_override"	"170 221 183 155"
+			
+			"sound_depressed"		"UI/buttonclick.wav"
+			"sound_released"		"UI/buttonclickrelease.wav"
+			
+			"pin_to_sibling"		"Map3"
+			"pin_corner_to_sibling"		"1"
+		}
+
+		"Map3"
+		{
+			"ControlName"			"Button"
+			"fieldName"			"Map3"
+			"xpos"				"1"
+			"zpos"				"100"
+			"wide"				"30"
+			"tall"				"f6"
+			"visible"			"1"
+			"font"				"HudFontSmallBold"
+			"textAlignment"			"center"
+			"command"			"engine next_map_vote 2"
+			"proportionaltoparent"		"1"
+			"labeltext"			"3"
+			"actionsignallevel"		"3"
+			"roundedcorners"		"0"
+			"textinsety"			"5"
+			"use_proportional_insets"	"1"
+			"paintbackground"		"0"
+			
+			"FgColor"			"TanLight"
+			"defaultFgColor_override"	"TanLight"
+			"armedFgColor_override"		"170 221 183 155"
+			"depressedFgColor_override"	"170 221 183 155"
+			
+			"sound_depressed"		"UI/buttonclick.wav"
+			"sound_released"		"UI/buttonclickrelease.wav"
+			
+			"pin_to_sibling"		"ResumeButton"
+			"pin_corner_to_sibling"		"1"
+		}
 	}
 }


### PR DESCRIPTION
Sometimes in Casual you cannot vote for a map at the end of a round. To reproduce this bug, play Casual until you see it, unfortunately it is not known exactly how this happens.
![flawhud map vote bug workaround](https://github.com/CriticalFlaw/flawhud/assets/117596825/518900d1-f21a-4759-b7ac-c1386b1ac6ad)