### PR TITLE
Moved up MVM Repawn/buyback Label [spectatortournament.res]

### DIFF
--- a/resource/ui/spectatortournament.res
+++ b/resource/ui/spectatortournament.res
@@ -337,7 +337,9 @@
 
 		if_mvm
 		{
-			"ypos"		"90"
+			"ypos"		"-2"
+			"xpos"		"1"
+			"font"		"FontRegular11"
 		}
 	}
 	
@@ -345,8 +347,8 @@
 	{
 		"ControlName"	"CExLabel"
 		"fieldName"		"BuyBackLabel"
-		"xpos"			"0"
-		"ypos"			"110"
+		"xpos"			"1"
+		"ypos"			"12"
 		"wide"			"f0"
 		"tall"			"14"
 		"autoResize"	"0"
@@ -355,7 +357,7 @@
 		"enabled"		"1"
 		"labelText"		"#TF_PVE_Buyback"
 		"textAlignment"	"center"
-		"font"			"FontRegular15"
+		"font"			"FontRegular11"
 		"wrap"			"1"
 		"centerwrap"	"1"
 


### PR DESCRIPTION
**Before**
Example provided by floatingtrash
![image (2)](https://github.com/CriticalFlaw/flawhud/assets/145300650/ce637535-8ff8-4087-a4f5-0870be49d4dd)

Fresh install from github and hud editor yielded
![image](https://github.com/CriticalFlaw/flawhud/assets/145300650/55fcc58d-28f7-40a5-8243-4a491a3e01da)

**After**
https://github.com/CriticalFlaw/flawhud/assets/145300650/e1daddde-7049-4806-b2b1-49d5d99e7f8f

Good enough I guess.