### PR TITLE
Expanded number of available backpack pages 

### DIFF
--- a/resource/ui/econ/backpackpanel.res
+++ b/resource/ui/econ/backpackpanel.res
@@ -34,9 +34,9 @@
 		"button_override_delete_xpos"	"0"
 
 		"page_button_y"					"288"
-		"page_button_x_delta"			"5"
-		"page_button_y_delta"			"5"
-		"page_button_per_row"			"15"
+		"page_button_x_delta"			"4"
+		"page_button_y_delta"			"4"
+		"page_button_per_row"			"20"
 		"page_button_height"			"15"
 
 		"pagebuttons_kv"
@@ -54,7 +54,7 @@
 			{
 				"fieldName"				"Button"
 				"ControlName"			"CExButton"
-				"wide"					"34"
+				"wide"					"25"
 				"tall"					"15"
 				"visible"				"1"
 				"bgcolor_override"		"Transparent"

--- a/resource/ui/econ/backpackpanel.res
+++ b/resource/ui/econ/backpackpanel.res
@@ -77,7 +77,7 @@
 				"ypos"					"0"
 				"xpos"					"0"
 				"zpos"					"0"
-				"wide"					"f1"
+				"wide"					"f0"
 				"tall"					"f-5"
 				"textinsetx"			"8"
 				"autoResize"			"1"


### PR DESCRIPTION
I do not have 80 pages to test this. The update increase max inventory size to 4000/80 pages (up from 3000/60 pages). But this keeps the page buttons limited to 4 rows of 20 (previously 4 rows of 15). The new button size has been shrunk down a good bit as a result.

**before (from friend)**
pages above 60 get cut off
![image](https://github.com/user-attachments/assets/e44e53d2-118a-49c8-ad58-ba5cad549a25)
![1710799748 3_image](https://github.com/user-attachments/assets/47e7bb89-d736-458b-835b-2cb150cdda92)

**after**
![image](https://github.com/user-attachments/assets/b78816ce-ca81-4df6-b951-5d266f3deba0)
![1762526805 6999998_image](https://github.com/user-attachments/assets/a12f69fe-be28-4c55-9d46-a6cdbbf7b30b)