### PR TITLE
Quickplay Core Fix

### DIFF
--- a/resource/ui/matchmakingplaylist.res
+++ b/resource/ui/matchmakingplaylist.res
@@ -266,7 +266,7 @@
 			"bgcolor_override"		"BGBlack"
 			"proportionaltoparent"	"1"
 			"paintBackground"		"0"
-			"urlText"				"https://comfig.app/quickplay/?gm=core"
+			"urlText"				"https://comfig.app/quickplay/?gm=any"
 		}
 	}
 	


### PR DESCRIPTION
Fixes the current link to Quickplay Core so it actually picks the Core Gamemodes (It doesnt do so currently)

Despite what the new link may suggest, it only picks the core gamemodes and not all of them as said by Mastercoms

![image](https://github.com/user-attachments/assets/e8fe6036-a950-4fa4-9ec6-132543c44311)

