### PR TITLE
Scoreboard Clean Up

### DIFF
--- a/resource/ui/mvmscoreboard.res
+++ b/resource/ui/mvmscoreboard.res
@@ -6,7 +6,6 @@
 		"fieldName"			"WaveStatusPanel"
 		"xpos"				"c-300"
 		"ypos"				"0"
-		"zpos"				"0"
 		"wide"				"600"
 		"tall"				"67"
 		"verbose"			"1"
@@ -20,10 +19,12 @@
 		"labelText"			"%popfile%"
 		"textAlignment"		"east"
 		"textinsetx"		"1"
-		"xpos"				"c-278"
-		"ypos"				"74"
-		"wide"				"550"
-		"tall"				"20"
+		"xpos"				"0"
+		"ypos"				"0"
+		"wide"				"547"
+		"tall"				"11"
+		"pin_to_sibling"			"PlayerListBG"
+		"pin_corner_to_sibling"		"PIN_BOTTOMLEFT"
 	}
 
 	"PlayerListBackground"
@@ -43,7 +44,7 @@
 		"zpos"				"-1"
 		"wide"				"550"
 		"tall"				"150"
-		"bgcolor_override"		"25 25 25 200"
+		"bgcolor_override"		"HudBlack"
 		"PaintBackgroundType"	"2"
 	}
 
@@ -85,10 +86,9 @@
 			"fieldName"		"CreditStatsBG"
 			"xpos"			"0"
 			"ypos"			"0"
-			"zpos"			"-1"
 			"wide"			"275"
 			"tall"			"132"
-			"bgcolor_override"		"25 25 25 200"
+			"bgcolor_override"		"HudBlack"
 			"PaintBackgroundType"	"2"
 
 		}

--- a/resource/ui/mvmscoreboard.res
+++ b/resource/ui/mvmscoreboard.res
@@ -9,8 +9,6 @@
 		"zpos"				"0"
 		"wide"				"600"
 		"tall"				"67"
-		"visible"			"1"
-		"enabled"			"1"
 		"verbose"			"1"
 	}
 
@@ -25,26 +23,14 @@
 		"ypos"				"74"
 		"wide"				"550"
 		"tall"				"20"
-		"fgcolor"			"TanLight"
 	}
 
 	"PlayerListBackground"
 	{
 		"ControlName"		"ScalableImagePanel"
 		"fieldName"			"PlayerListBackground"
-		"xpos"				"0"
-		"ypos"				"0"
-		"zpos"				"0"
-		"wide"				"0"
-		"tall"				"0"
 		"visible"			"0"
 		"enabled"			"0"
-		"image"				"../hud/tournament_panel_brown"
-		"scaleImage"		"0"
-		"src_corner_height"		"0"
-		"src_corner_width"		"0"
-		"draw_corner_width"		"0"
-		"draw_corner_height" 	"0"
 	}
 
 	"PlayerListBG"
@@ -56,8 +42,6 @@
 		"zpos"				"-1"
 		"wide"				"550"
 		"tall"				"150"
-		"visible"			"1"
-		"enabled"			"1"
 		"bgcolor_override"		"25 25 25 200"
 		"PaintBackgroundType"	"2"
 	}
@@ -71,10 +55,6 @@
 		"wide"				"550"
 		"wide_minmode"		"0"
 		"tall"				"145"
-		"pinCorner"			"0"
-		"visible"			"1"
-		"enabled"			"1"
-		"tabPosition"		"0"
 		"autoresize"		"3"
 		"linespacing"		"22"
 		"textcolor"			"TanLight"
@@ -89,26 +69,14 @@
 		"ypos"				"245"
 		"wide"				"275"
 		"tall"				"132"
-		"visible"			"1"
 
 		"CreditStatsBackground"
 		{
 			"ControlName"	"ScalableImagePanel"
 			"fieldName"		"CreditStatsBackground"
-			"xpos"			"0"
-			"ypos"			"0"
-			"zpos"			"0"
 			"wide"			"0"
-			"tall"			"0"
-			"autoResize"	"0"
-			"pinCorner"		"0"
 			"visible"		"0"
 			"enabled"		"0"
-			"image"			"../HUD/tournament_panel_brown"
-			"src_corner_height"		"0"
-			"src_corner_width"		"0"
-			"draw_corner_width"		"0"
-			"draw_corner_height" 	"0"
 		}
 		"CreditStatsBG"
 		{
@@ -119,8 +87,6 @@
 			"zpos"			"-1"
 			"wide"			"275"
 			"tall"			"132"
-			"visible"		"1"
-			"enabled"		"1"
 			"bgcolor_override"		"25 25 25 200"
 			"PaintBackgroundType"	"2"
 
@@ -137,7 +103,6 @@
 			"ypos"			"5"
 			"wide"			"275"
 			"tall"			"20"
-			"fgcolor"		"TanLight"
 		}
 
 		"PreviousWaveCreditInfoPanel"
@@ -148,20 +113,6 @@
 			"ypos"			"30"
 			"wide"			"130"
 			"tall"			"60"
-			"wide"			"200"
-			"visible"		"1"
-		}
-
-		"TotalGameCreditInfoPanel"
-		{
-			"ControlName"	"CCreditDisplayPanel"
-			"fieldName"		"TotalGameCreditInfoPanel"
-			"xpos"			"153"
-			"ypos"			"30"
-			"wide"			"130"
-			"tall"			"60"
-			"wide"			"200"
-			"visible"		"1"
 		}
 
 		"PreviousWaveCreditSpendPanel"
@@ -172,8 +123,6 @@
 			"ypos"			"72"
 			"wide"			"130"
 			"tall"			"60"
-			"wide"			"200"
-			"visible"		"1"
 		}
 
 		"TotalGameCreditSpendPanel"
@@ -184,8 +133,16 @@
 			"ypos"			"72"
 			"wide"			"130"
 			"tall"			"60"
-			"wide"			"200"
-			"visible"		"1"
+		}
+
+		"TotalGameCreditInfoPanel"
+		{
+			"ControlName"	"CCreditDisplayPanel"
+			"fieldName"		"TotalGameCreditInfoPanel"
+			"xpos"			"153"
+			"ypos"			"30"
+			"wide"			"130"
+			"tall"			"60"
 		}
 
 		"RespecStatusLabel"
@@ -199,7 +156,6 @@
 			"ypos"			"8"
 			"wide"			"275"
 			"tall"			"20"
-			"fgcolor"		"TanLight"
 		}
 	}
 }

--- a/resource/ui/mvmscoreboard.res
+++ b/resource/ui/mvmscoreboard.res
@@ -20,7 +20,7 @@
 		"labelText"			"%popfile%"
 		"textAlignment"		"east"
 		"textinsetx"		"1"
-		"xpos"				"c-279"
+		"xpos"				"c-278"
 		"ypos"				"74"
 		"wide"				"550"
 		"tall"				"20"

--- a/resource/ui/mvmscoreboard.res
+++ b/resource/ui/mvmscoreboard.res
@@ -4,7 +4,7 @@
 	{
 		"ControlName"		"CWaveStatusPanel"
 		"fieldName"			"WaveStatusPanel"
-		"xpos"				"-35"
+		"xpos"				"c-300"
 		"ypos"				"0"
 		"zpos"				"0"
 		"wide"				"600"
@@ -19,7 +19,8 @@
 		"font"				"FontRegular10"
 		"labelText"			"%popfile%"
 		"textAlignment"		"east"
-		"xpos"				"0"
+		"textinsetx"		"1"
+		"xpos"				"c-279"
 		"ypos"				"74"
 		"wide"				"550"
 		"tall"				"20"
@@ -37,7 +38,7 @@
 	{
 		"ControlName"		"EditablePanel"
 		"fieldName"			"PlayerListBG"
-		"xpos"				"0"
+		"xpos"				"c-275"
 		"ypos"				"90"
 		"zpos"				"-1"
 		"wide"				"550"
@@ -65,7 +66,7 @@
 	{
 		"ControlName"		"EditablePanel"
 		"fieldName"			"CreditStatsContainer"
-		"xpos"				"0"
+		"xpos"				"c-275"
 		"ypos"				"245"
 		"wide"				"275"
 		"tall"				"132"

--- a/resource/ui/scoreboard.res
+++ b/resource/ui/scoreboard.res
@@ -340,8 +340,10 @@
 
 		if_mvm
 		{
-			"xpos"				"-25"
-			"ypos"				"-55"
+			"xpos"				"c-275" //MVM StatsBG anchor
+			"ypos"				"64"
+			"wide"				"550"
+			"pin_to_sibling"		""
 			"visible"			"0"
 		}
 	}
@@ -457,11 +459,10 @@
 
 		if_mvm
 		{
-			"xpos"				"3"
 			"ypos"				"-181"
 			"wide"				"270"
 			"tall"				"132"
-			"pin_to_sibling"		"mapname"
+			"pin_to_sibling"		"ServerBackground"
 			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
 			"pin_to_sibling_corner"	"PIN_TOPRIGHT"
 		}
@@ -854,7 +855,7 @@
 			"textAlignment"				"east"
 			"xpos"						"0"
 			"ypos"						"0"
-			"wide"						"80"
+			"wide"						"100"
 			"tall"						"50"
 
 			"pin_to_sibling"			"KillsLabel"
@@ -1560,16 +1561,25 @@
 			"tall"				"f0"
 			"linecolor"			"TanLight"
 		}
+
+		if_mvm
+		{
+			"zpos"			"998"
+		}
 	}
 	
 	"DrawingBoardRight"
 	{
 		"ControlName"	"EditablePanel"
-		"xpos"			"c-290"
+		"xpos"			"-20"
 		"ypos"			"0"
 		"zpos"			"-1"
 		"wide"			"f0"
 		"tall"			"f0"
+
+		"pin_to_sibling"			"classmodelpanel"
+		"pin_corner_to_sibling"		"PIN_BOTTOMLEFT" 
+		"pin_to_sibling_corner"		"PIN_BOTTOMRIGHT"
 		
 		"Draw"
 		{

--- a/resource/ui/scoreboard.res
+++ b/resource/ui/scoreboard.res
@@ -102,8 +102,6 @@
 		"TextInsetX"		"15"
 
 		"pin_to_sibling"		"BlueBG"
-		"pin_corner_to_sibling"	"PIN_TOPLEFT"
-		"pin_to_sibling_corner"	"PIN_TOPLEFT"
 
 		if_mvm
 		{
@@ -134,12 +132,14 @@
 		{
 			"font"				"FontRegular10"
 			"textAlignment"		"west"
-			"xpos"				"294"
-			"ypos"				"-245"
+			"TextInsetX"		"0"
+			"xpos"				"0"
+			"ypos"				"-100"
 			"zpos"				"11"
-			"wide"				"50"
+			"wide"				"44"
 			"tall"				"20"
 			"fgcolor"			"DisguiseMenuIconBlue"
+			"pin_to_sibling"		"StatsBG"
 		}
 	}
 
@@ -181,8 +181,6 @@
 		"bgcolor_override"		"RedTeam"
 
 		"pin_to_sibling"		"RedBG"
-		"pin_corner_to_sibling"	"PIN_TOPLEFT"
-		"pin_to_sibling_corner"	"PIN_TOPLEFT"
 
 		if_mvm
 		{
@@ -274,8 +272,6 @@
 		"TextInsetX"		"23"
 
 		"pin_to_sibling"		"RedBG"
-		"pin_corner_to_sibling"	"PIN_TOPLEFT"
-		"pin_to_sibling_corner"	"PIN_TOPLEFT"
 
 		if_mvm
 		{
@@ -349,11 +345,12 @@
 		if_mvm
 		{
 			"font"				"FontRegular10"
-			"xpos"				"c-270"
-			"ypos"				"78"
+			"xpos"				"c-271"
+			"ypos"				"79"
 			"pin_to_sibling"	""
 		}
 	}
+
 	"ServerTimeBackground"
 	{
 		"ControlName"		"EditablePanel"
@@ -375,6 +372,7 @@
 			"visible"			"0"
 		}
 	}
+
 	"ServerTimeLabel"
 	{
 		"ControlName"		"CExLabel"
@@ -446,13 +444,14 @@
 		"fieldName"			"Spectators"
 		"font"				"FontRegular11"
 		"labelText"			"%spectators%"
-		"textAlignment"		"west"
+		"textAlignment"		"north-west"
+		"wrap"				"1"
 		"xpos"				"-2"
-		"ypos"				"0"
+		"ypos"				"1"
 		"zpos"				"4"
-		"wide"				"577"
+		"wide"				"370"
 		"wide_minmode"		"0"
-		"tall"				"11"
+		"tall"				"22"
 
 		"pin_to_sibling"		"StatsBG"
 		"pin_corner_to_sibling"	"PIN_TOPLEFT"
@@ -460,8 +459,8 @@
 
 		if_mvm
 		{
-			"xpos"				"275"
-		    "wide"				"544"
+			"xpos"				"276"
+		    "wide"				"546"
 		}
 	}
 
@@ -471,8 +470,7 @@
 		"fieldName"			"StatsBG"
 		"xpos"				"0"
 		"ypos"				"2"
-		"zpos"				"2"
-		"wide"				"581"
+		"wide"				"582"
 		"tall"				"50"
 		"bgcolor_override"	"25 25 25 200"
 		"PaintBackgroundType"	"2"
@@ -484,7 +482,7 @@
 
 		if_mvm
 		{
-			"xpos"				"4"
+			"xpos"				"3"
 			"ypos"				"166"
 			"wide"				"270"
 			"tall"				"132"
@@ -494,23 +492,20 @@
 		}
 	}
 
-	"SpectatorsInQueue"
+	"SpectatorsInQueue" //(arena) does not work, even on stock hud. Only shows 1 player at a time.
 	{
 		"ControlName"		"CExLabel"
 		"fieldName"			"SpectatorsInQueue"
 		"font"				"FontRegular11"
 		"labelText"			"%waitingtoplay%"
-		"textAlignment"		"west"
+		"textAlignment"		"north-west"
 		"xpos"				"-2"
-		"ypos"				"30"
+		"ypos"				"-72"
 		"zpos"				"4"
 		"wide"				"577"
 		"wide_minmode"		"0"
 		"tall"				"20"
-
 		"pin_to_sibling"		"StatsBG"
-		"pin_corner_to_sibling"	"PIN_BOTTOMLEFT"
-		"pin_to_sibling_corner"	"PIN_BOTTOMLEFT"
 
 		if_mvm
 		{
@@ -601,37 +596,36 @@
 		"fieldName"			"mapname"
 		"font"				"FontRegular11"
 		"labelText"			"%mapname%"
-		"textAlignment"		"center"
-		"xpos"				"-35"
-		"ypos"				"-5"
+		"textAlignment"		"north-east"
+		"xpos"				"-2"
+		"ypos"				"1"
 		"zpos"				"5"
-		"wide"				"100"
+		"wide"				"210"
 		"tall"				"15"
 		"allcaps"			"1"
 
 		"pin_to_sibling"		"StatsBG"
-		"pin_corner_to_sibling"	"PIN_BOTTOMRIGHT"
+		"pin_corner_to_sibling"	"PIN_TOPRIGHT"
 		"pin_to_sibling_corner"	"PIN_BOTTOMRIGHT"
 
 		if_mvm
 		{
-			"xpos"				"c-279"
+			"xpos"				"c-278"
 			"ypos"				"64"
 			"wide"				"550"
 			"textAlignment"		"east"
 			"pin_to_sibling"		""
 		}
 	}
+
 	"HorizontalLine"
 	{
 		"ControlName"		"ImagePanel"
 		"fieldName"			"HorizontalLine"
-		"zpos"				"3"
 		"wide"				"0"
 		"visible"			"0"
 		"enabled"			"0"
 	}
-
 	"PlayerScoreLabel"
 	{
 		"ControlName"		"CExLabel"
@@ -851,182 +845,127 @@
 
 	"LocalPlayerStatsPanel"
 	{
-		"ControlName"		"EditablePanel"
-		"fieldName"			"LocalPlayerStatsPanel"
-		"xpos"				"0"
-		"ypos"				"0"
-		"zpos"				"3"
-		"wide"				"585"
-		"tall"				"50"
-		"pin_to_sibling"	"StatsBG"
-
-		if_mvm
+		"ControlName"			"EditablePanel"
+		"fieldName"				"LocalPlayerStatsPanel"
+		"xpos"					"0"
+		"ypos"					"0"
+		"zpos"					"1"
+		"wide"					"582"
+		"tall"					"50"
+		"pin_to_sibling"		"StatsBG"
+		
+		"if_mvm"
 		{
-			"wide"				"270"
-			"tall"				"132"
+			"wide"		"270"
+			"tall"		"132"
 		}
 
 		"KillsLabel"
 		{
-			"ControlName"		"CExLabel"
-			"fieldName"			"KillsLabel"
-			"font"				"FontBold37"
-			"labelText"			":"
-			"textAlignment"		"center"
-			"xpos"				"65"
-			"ypos"				"0"
-			"zpos"				"3"
-			"wide"				"20"
-			"tall"				"50"
-
+			"ControlName"			"CExLabel"
+			"fieldName"				"KillsLabel"
+			"font"					"FontBold37"
+			"labelText"				":"
+			"textAlignment"			"center"
+			"textinsetx"			"10"
+			"xpos"					"76"
+			"ypos"					"0"
+			"wide"					"15"
+			"tall"					"50"
 			"pin_to_sibling"		"StatsBG"
-			"pin_corner_to_sibling"	"PIN_TOPLEFT"
-			"pin_to_sibling_corner"	"PIN_TOPLEFT"
 
-			if_mvm
+			"if_mvm"
 			{
-				"xpos"				"117"
-				"ypos"				"0"
+				"xpos"		"128"
+				"ypos"		"1"
 			}
-		}
-		"Kills"
-		{
-			"ControlName"		"CExLabel"
-			"fieldName"			"Kills"
-			"labelText"			"%kills%"
-			"xpos"				"0"
-			"ypos"				"0"
-			"wide"				"80"
-			"tall"				"50"
-			"visible"			"0"
-			"enabled"			"0"
-			"fgcolor"			"TanLight"
-
-			"pin_to_sibling"		"KillsLabel"
-			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
-			"pin_to_sibling_corner"	"PIN_TOPLEFT"
 		}
 		"Kills2"
 		{
-			"ControlName"		"CExLabel"
-			"fieldName"			"Kills2"
-			"font"				"FontBold37"
-			"labelText"			"%kills%"
-			"textAlignment"		"east"
-			"xpos"				"0"
-			"ypos"				"0"
-			"zpos"				"3"
-			"wide"				"80"
-			"tall"				"50"
-			"fgcolor"			"TanLight"
-			"pin_to_sibling"	"Kills"
+			"ControlName"				"CExLabel"
+			"fieldName"					"Kills2"
+			"font"						"FontBold37"
+			"labelText"					"%kills%"
+			"textAlignment"				"east"
+			"xpos"						"0"
+			"ypos"						"0"
+			"wide"						"80"
+			"tall"						"50"
+
+			"pin_to_sibling"			"KillsLabel"
+			"pin_corner_to_sibling"		"PIN_TOPRIGHT"
+			"pin_to_sibling_corner"		"PIN_TOPLEFT"
 		}
 
 		"DeathsLabel"
 		{
 			"ControlName"		"CExLabel"
 			"fieldName"			"DeathsLabel"
-			"wide"				"0"
 			"visible"			"0"
 			"enabled"			"0"
 		}
-		"Deaths"
-		{
-			"ControlName"		"CExLabel"
-			"fieldName"			"Deaths"
-			"labelText"			"%deaths%"
-			"xpos"				"0"
-			"ypos"				"0"
-			"wide"				"80"
-			"tall"				"50"
-			"visible"			"0"
-			"enabled"			"0"
 
-			"pin_to_sibling"		"KillsLabel"
-			"pin_corner_to_sibling"	"PIN_TOPLEFT"
-			"pin_to_sibling_corner"	"PIN_TOPRIGHT"
-		}
 		"Deaths2"
 		{
-			"ControlName"		"CExLabel"
-			"fieldName"			"Deaths2"
-			"font"				"FontBold37"
-			"labelText"			"%deaths%"
-			"textAlignment"		"west"
-			"xpos"				"0"
-			"ypos"				"0"
-			"zpos"				"3"
-			"wide"				"80"
-			"tall"				"50"
-			"pin_to_sibling"	"Deaths"
+			"ControlName"				"CExLabel"
+			"fieldName"					"Deaths2"
+			"font"						"FontBold37"
+			"labelText"					"%deaths%"
+			"textAlignment"				"west"
+			"xpos"						"0"
+			"ypos"						"0"
+			"wide"						"80"
+			"tall"						"50"
+
+			"pin_to_sibling"			"KillsLabel"
+			"pin_corner_to_sibling"		"PIN_TOPLEFT"
+			"pin_to_sibling_corner"		"PIN_TOPRIGHT"
 		}
 
 		"GameType"
 		{
 			"ControlName"		"CExLabel"
 			"fieldName"			"gametype"
-			"wide"				"0"
 			"visible"			"0"
 			"enabled"			"0"
 		}
 
 		"AssistsLabel"
 		{
-			"ControlName"		"CExLabel"
-			"fieldName"			"AssistsLabel"
-			"font"				"FontRegular11"
-			"labelText"			"#TF_ScoreBoard_AssistsLabel"
-			"textAlignment"		"east"
-			"xpos"				"140"
-			"ypos"				"2"
-			"zpos"				"3"
-			"wide"				"50"
-			"tall"				"20"
-
+			"ControlName"			"CExLabel"
+			"fieldName"				"AssistsLabel"
+			"font"					"FontRegular11"
+			"labelText"				"#TF_ScoreBoard_AssistsLabel"
+			"textAlignment"			"east"
+			"xpos"					"150"
+			"ypos"					"3"
+			"wide"					"60"
+			"tall"					"20"
 			"pin_to_sibling"		"StatsBG"
-			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
-			"pin_to_sibling_corner"	"PIN_TOPRIGHT"
 
-			if_mvm
+			"if_mvm"
 			{
 				"font"		"FontRegular10"
-				"xpos"		"0"
+				"xpos"		"6"
 				"ypos"		"50"
 			}
 		}
-		"Assists"
-		{
-			"ControlName"		"CExLabel"
-			"fieldName"			"Assists"
-			"labelText"			"%assists%"
-			"xpos"				"35"
-			"ypos"				"0"
-			"wide"				"30"
-			"tall"				"20"
-			"visible"			"0"
-			"enabled"			"0"
-			"pin_to_sibling"		"AssistsLabel"
-			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
-			"pin_to_sibling_corner"	"PIN_TOPRIGHT"
-		}
 		"Assists2"
 		{
-			"ControlName"		"CExLabel"
-			"fieldName"			"Assists2"
-			"font"				"FontRegular11"
-			"labelText"			"%assists%"
-			"textAlignment"		"west"
-			"xpos"				"0"
-			"ypos"				"0"
-			"zpos"				"3"
-			"wide"				"30"
-			"tall"				"20"
+			"ControlName"				"CExLabel"
+			"fieldName"					"Assists2"
+			"font"						"FontRegular11"
+			"labelText"					"%assists%"
+			"textAlignment"				"west"
+			"xpos"						"3"
+			"ypos"						"0"
+			"wide"						"30"
+			"tall"						"20"
+			"pin_to_sibling"			"AssistsLabel"
+			"pin_corner_to_sibling"		"PIN_TOPLEFT"
+			"pin_to_sibling_corner"		"PIN_TOPRIGHT"
 
-			"pin_to_sibling"		"Assists"
-			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
-			"pin_to_sibling_corner"	"PIN_TOPRIGHT"
-
-			if_mvm
+			"if_mvm"
 			{
 				"font"		"FontRegular10"
 			}
@@ -1034,66 +973,42 @@
 
 		"DestructionLabel"
 		{
-			"ControlName"		"CExLabel"
-			"fieldName"			"DestructionLabel"
-			"font"				"FontRegular11"
-			"labelText"			"#TF_ScoreBoard_DestructionLabel"
-			"textAlignment"		"east"
-			"xpos"				"0"
-			"ypos"				"12"
-			"zpos"				"3"
-			"wide"				"60"
-			"tall"				"20"
-			
+			"ControlName"			"CExLabel"
+			"fieldName"				"DestructionLabel"
+			"font"					"FontRegular11"
+			"labelText"				"#TF_ScoreBoard_DestructionLabel"
+			"textAlignment"			"east"
+			"xpos"					"0"
+			"ypos"					"-12"
+			"wide"					"60"
+			"tall"					"20"
 			"pin_to_sibling"		"AssistsLabel"
-			"pin_corner_to_sibling"	"PIN_BOTTOMRIGHT"
-			"pin_to_sibling_corner"	"PIN_BOTTOMRIGHT"
 
-			if_mvm
+			"if_mvm"
 			{
-				"font"		"FontRegular10"
-				"xpos"		"0"
-				"ypos"		"50"
-				
+				"font"					"FontRegular10"
+				"xpos"					"0"
+				"ypos"					"-50"
 				"pin_to_sibling"		"HeadshotsLabel"
-				"pin_corner_to_sibling"	"PIN_BOTTOMRIGHT"
-				"pin_to_sibling_corner"	"PIN_BOTTOMRIGHT"
+				
 			}
-		}
-		"Destruction"
-		{
-			"ControlName"		"CExLabel"
-			"fieldName"			"Destruction"
-			"labelText"			"%destruction%"
-			"xpos"				"35"
-			"ypos"				"0"
-			"wide"				"30"
-			"tall"				"20"
-			"visible"			"0"
-			"enabled"			"0"
-			
-			"pin_to_sibling"		"DestructionLabel"
-			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
-			"pin_to_sibling_corner"	"PIN_TOPRIGHT"
 		}
 		"Destruction2"
 		{
-			"ControlName"		"CExLabel"
-			"fieldName"			"Destruction2"
-			"font"				"FontRegular11"
-			"labelText"			"%destruction%"
-			"textAlignment"		"west"
-			"xpos"				"0"
-			"ypos"				"0"
-			"zpos"				"3"
-			"wide"				"30"
-			"tall"				"20"
+			"ControlName"				"CExLabel"
+			"fieldName"					"Destruction2"
+			"font"						"FontRegular11"
+			"labelText"					"%destruction%"
+			"textAlignment"				"west"
+			"xpos"						"3"
+			"ypos"						"0"
+			"wide"						"30"
+			"tall"						"20"
+			"pin_to_sibling"			"DestructionLabel"
+			"pin_corner_to_sibling"		"PIN_TOPLEFT"
+			"pin_to_sibling_corner"		"PIN_TOPRIGHT"
 
-			"pin_to_sibling"		"Destruction"
-			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
-			"pin_to_sibling_corner"	"PIN_TOPRIGHT"
-
-			if_mvm
+			"if_mvm"
 			{
 				"font"		"FontRegular10"
 			}
@@ -1101,60 +1016,120 @@
 
 		"CapturesLabel"
 		{
-			"ControlName"		"CExLabel"
-			"fieldName"			"CapturesLabel"
-			"font"				"FontRegular11"
-			"labelText"			"#TF_ScoreBoard_CapturesLabel"
-			"textAlignment"		"east"
-			"xpos"				"0"
-			"ypos"				"12"
-			"zpos"				"3"
-			"wide"				"50"
-			"tall"				"20"
-
+			"ControlName"			"CExLabel"
+			"fieldName"				"CapturesLabel"
+			"font"					"FontRegular11"
+			"labelText"				"#TF_ScoreBoard_CapturesLabel"
+			"textAlignment"			"east"
+			"xpos"					"0"
+			"ypos"					"-12"
+			"wide"					"60"
+			"tall"					"20"
 			"pin_to_sibling"		"DestructionLabel"
-			"pin_corner_to_sibling"	"PIN_BOTTOMRIGHT"
-			"pin_to_sibling_corner"	"PIN_BOTTOMRIGHT"
 
-			if_mvm
+			"if_mvm"
 			{
-				"visible"			"0"
+				"visible"		"0"
 			}
-		}
-		"Captures"
-		{
-			"ControlName"		"CExLabel"
-			"fieldName"			"Captures"
-			"labelText"			"%captures%"
-			"xpos"				"35"
-			"ypos"				"0"
-			"wide"				"30"
-			"tall"				"20"
-			"visible"			"0"
-			"enabled"			"0"
-
-			"pin_to_sibling"		"CapturesLabel"
-			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
-			"pin_to_sibling_corner"	"PIN_TOPRIGHT"
 		}
 		"Captures2"
 		{
-			"ControlName"		"CExLabel"
-			"fieldName"			"Captures2"
-			"font"				"FontRegular11"
-			"labelText"			"%captures%"
-			"textAlignment"		"west"
-			"xpos"				"0"
-			"ypos"				"0"
-			"zpos"				"3"
-			"wide"				"30"
-			"tall"				"20"
+			"ControlName"				"CExLabel"
+			"fieldName"					"Captures2"
+			"font"						"FontRegular11"
+			"labelText"					"%captures%"
+			"textAlignment"				"west"
+			"xpos"						"3"
+			"ypos"						"0"
+			"wide"						"30"
+			"tall"						"20"
 
-			"pin_to_sibling"		"Captures"
-			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
-			"pin_to_sibling_corner"	"PIN_TOPRIGHT"
+			"pin_to_sibling"			"CapturesLabel"
+			"pin_corner_to_sibling"		"PIN_TOPLEFT"
+			"pin_to_sibling_corner"		"PIN_TOPRIGHT"
 
-			if_mvm
+			"if_mvm"
+			{
+				"visible"		"0"
+			}
+		}
+		
+		"DominationLabel"
+		{
+			"ControlName"			"CExLabel"
+			"fieldName"				"DominationLabel"
+			"font"					"FontRegular11"
+			"labelText"				"#TF_ScoreBoard_DominationLabel"
+			
+			"textAlignment"			"east"
+			"xpos"					"-85"
+			"ypos"					"0"
+			"wide"					"60"
+			"tall"					"20"
+			"pin_to_sibling"		"AssistsLabel"
+
+			"if_mvm"
+			{
+				"visible"		"0"
+			}
+		}
+		"Domination2"
+		{
+			"ControlName"				"CExLabel"
+			"fieldName"					"Domination2"
+			"font"						"FontRegular11"
+			"labelText"					"%dominations%"
+			"textAlignment"				"west"
+			"xpos"						"3"
+			"ypos"						"0"
+			"wide"						"30"
+			"tall"						"20"
+
+			"pin_to_sibling"			"DominationLabel"
+			"pin_corner_to_sibling"		"PIN_TOPLEFT"
+			"pin_to_sibling_corner"		"PIN_TOPRIGHT"
+
+			"if_mvm"
+			{
+				"visible"		"0"
+			}
+		}
+
+		"RevengeLabel"
+		{
+			"ControlName"			"CExLabel"
+			"fieldName"				"RevengeLabel"
+			"font"					"FontRegular11"
+			"labelText"				"#TF_ScoreBoard_RevengeLabel"
+			"textAlignment"			"east"
+			"xpos"					"0"
+			"ypos"					"-12"
+			"wide"					"60"
+			"tall"					"20"
+			"pin_to_sibling"		"DominationLabel"
+
+			"if_mvm"
+			{
+				"visible"		"0"
+			}
+		}
+		"Revenge2"
+		{
+			"ControlName"				"CExLabel"
+			"fieldName"					"Revenge2"
+			"font"						"FontRegular11"
+			"labelText"					"%Revenge%"
+			"textAlignment"				"west"
+			"xpos"						"3"
+			"ypos"						"0"
+			"wide"						"30"
+			"tall"						"20"
+
+			"pin_to_sibling"			"RevengeLabel"
+			"pin_corner_to_sibling"		"PIN_TOPLEFT"
+			"pin_to_sibling_corner"		"PIN_TOPRIGHT"
+
+			"if_mvm"
 			{
 				"visible"		"0"
 			}
@@ -1162,765 +1137,429 @@
 
 		"DefensesLabel"
 		{
-			"ControlName"		"CExLabel"
-			"fieldName"			"DefensesLabel"
-			"font"				"FontRegular11"
-			"labelText"			"#TF_ScoreBoard_DefensesLabel"
-			"textAlignment"		"east"
-			"xpos"				"80"
-			"ypos"				"0"
-			"zpos"				"3"
-			"wide"				"50"
-			"tall"				"20"
+			"ControlName"			"CExLabel"
+			"fieldName"				"DefensesLabel"
+			"font"					"FontRegular11"
+			"labelText"				"#TF_ScoreBoard_DefensesLabel"
+			"textAlignment"			"east"
+			"xpos"					"0"
+			"ypos"					"-12"
+			"wide"					"60"
+			"tall"					"20"
+			"pin_to_sibling"		"RevengeLabel"
 
-			"pin_to_sibling"		"AssistsLabel"
-			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
-			"pin_to_sibling_corner"	"PIN_TOPRIGHT"
-			
-			if_mvm
+			"if_mvm"
 			{
-				"font"		"FontRegular10"
-				"xpos"		"0"
-				"ypos"		"25"
-				
-				"pin_to_sibling"		"HeadshotsLabel"
-				"pin_corner_to_sibling"	"PIN_BOTTOMRIGHT"
-				"pin_to_sibling_corner"	"PIN_BOTTOMRIGHT"
+				"font"					"FontRegular10"
+				"ypos"					"-25"
+				"pin_to_sibling"		"AssistsLabel"
 			}
-		}
-		"Defenses"
-		{
-			"ControlName"		"CExLabel"
-			"fieldName"			"Defenses"
-			"labelText"			"%defenses%"
-			"xpos"				"35"
-			"ypos"				"0"
-			"wide"				"30"
-			"tall"				"20"
-			"visible"			"0"
-			"enabled"			"0"
-
-			"pin_to_sibling"		"DefensesLabel"
-			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
-			"pin_to_sibling_corner"	"PIN_TOPRIGHT"
 		}
 		"Defenses2"
 		{
-			"ControlName"		"CExLabel"
-			"fieldName"			"Defenses2"
-			"font"				"FontRegular11"
-			"labelText"			"%defenses%"
-			"textAlignment"		"west"
-			"xpos"				"0"
-			"ypos"				"0"
-			"zpos"				"3"
-			"wide"				"30"
-			"tall"				"20"
+			"ControlName"				"CExLabel"
+			"fieldName"					"Defenses2"
+			"font"						"FontRegular11"
+			"labelText"					"%defenses%"
+			"textAlignment"				"west"
+			"xpos"						"3"
+			"ypos"						"0"
+			"wide"						"30"
+			"tall"						"20"
+			
+			"pin_to_sibling"			"DefensesLabel"
+			"pin_corner_to_sibling"		"PIN_TOPLEFT"
+			"pin_to_sibling_corner"		"PIN_TOPRIGHT"
 
-			"pin_to_sibling"		"Defenses"
-			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
-			"pin_to_sibling_corner"	"PIN_TOPRIGHT"
-
-			if_mvm
+			"if_mvm"
 			{
-				"font"	"FontRegular10"
-			}
-		}
-
-		"DominationLabel"
-		{
-			"ControlName"		"CExLabel"
-			"fieldName"			"DominationLabel"
-			"font"				"FontRegular11"
-			"labelText"			"#TF_ScoreBoard_DominationLabel"
-			"textAlignment"		"east"
-			"xpos"				"0"
-			"ypos"				"12"
-			"zpos"				"3"
-			"wide"				"55"
-			"tall"				"20"
-
-			"pin_to_sibling"		"DefensesLabel"
-			"pin_corner_to_sibling"	"PIN_BOTTOMRIGHT"
-			"pin_to_sibling_corner"	"PIN_BOTTOMRIGHT"
-
-			if_mvm
-			{
-				"visible"			"0"
-			}
-		}
-		"Domination"
-		{
-			"ControlName"		"CExLabel"
-			"fieldName"			"Domination"
-			"labelText"			"%dominations%"
-			"xpos"				"35"
-			"ypos"				"0"
-			"wide"				"30"
-			"tall"				"20"
-			"visible"			"0"
-			"enabled"			"0"
-
-			"pin_to_sibling"		"DominationLabel"
-			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
-			"pin_to_sibling_corner"	"PIN_TOPRIGHT"
-		}
-		"Domination2"
-		{
-			"ControlName"		"CExLabel"
-			"fieldName"			"Domination2"
-			"font"				"FontRegular11"
-			"labelText"			"%dominations%"
-			"textAlignment"		"west"
-			"xpos"				"0"
-			"ypos"				"0"
-			"zpos"				"3"
-			"wide"				"30"
-			"tall"				"20"
-
-			"pin_to_sibling"		"Domination"
-			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
-			"pin_to_sibling_corner"	"PIN_TOPRIGHT"
-
-			if_mvm
-			{
-				"visible"			"0"
-			}
-		}
-
-		"RevengeLabel"
-		{
-			"ControlName"		"CExLabel"
-			"fieldName"			"RevengeLabel"
-			"font"				"FontRegular11"
-			"labelText"			"#TF_ScoreBoard_RevengeLabel"
-			"textAlignment"		"east"
-			"xpos"				"0"
-			"ypos"				"12"
-			"zpos"				"3"
-			"wide"				"50"
-			"tall"				"20"
-
-			"pin_to_sibling"		"DominationLabel"
-			"pin_corner_to_sibling"	"PIN_BOTTOMRIGHT"
-			"pin_to_sibling_corner"	"PIN_BOTTOMRIGHT"
-
-			if_mvm
-			{
-				"visible"			"0"
-			}
-		}
-		"Revenge"
-		{
-			"ControlName"		"CExLabel"
-			"fieldName"			"Revenge"
-			"labelText"			"%Revenge%"
-			"xpos"				"35"
-			"ypos"				"0"
-			"wide"				"30"
-			"tall"				"20"
-			"visible"			"0"
-			"enabled"			"0"
-
-			"pin_to_sibling"		"RevengeLabel"
-			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
-			"pin_to_sibling_corner"	"PIN_TOPRIGHT"
-		}
-		"Revenge2"
-		{
-			"ControlName"		"CExLabel"
-			"fieldName"			"Revenge2"
-			"font"				"FontRegular11"
-			"labelText"			"%Revenge%"
-			"textAlignment"		"west"
-			"xpos"				"0"
-			"ypos"				"0"
-			"zpos"				"3"
-			"wide"				"30"
-			"tall"				"20"
-
-			"pin_to_sibling"		"Revenge"
-			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
-			"pin_to_sibling_corner"	"PIN_TOPRIGHT"
-
-			if_mvm
-			{
-				"visible"			"0"
+				"font"		"FontRegular10"
 			}
 		}
 
 		"HealingLabel"
 		{
-			"ControlName"		"CExLabel"
-			"fieldName"			"HealingLabel"
-			"font"				"FontRegular11"
-			"labelText"			"#TF_ScoreBoard_HealingLabel"
-			"textAlignment"		"east"
-			"xpos"				"80"
-			"ypos"				"0"
-			"zpos"				"3"
-			"wide"				"50"
-			"tall"				"20"
-
-			"pin_to_sibling"		"DefensesLabel"
-			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
-			"pin_to_sibling_corner"	"PIN_TOPRIGHT"
-
-			if_mvm
+			"ControlName"			"CExLabel"
+			"fieldName"				"HealingLabel"
+			"font"					"FontRegular11"
+			"labelText"				"#TF_ScoreBoard_HealingLabel"
+			"textAlignment"			"east"
+			"xpos"					"-80"
+			"ypos"					"0"
+			"wide"					"50"
+			"tall"					"20"
+			"pin_to_sibling"		"DominationLabel"
+			
+			"if_mvm"
 			{
-				"visible"		"0" 
+				"font"						"FontRegular10"
+				"xpos"						"0"
+				"ypos"						"20"
+				"visible"					"0"
+				"pin_to_sibling"			"AssistsLabel"
+				"pin_corner_to_sibling"		"PIN_BOTTOMRIGHT"
+				"pin_to_sibling_corner"		"PIN_BOTTOMRIGHT"
 			}
-		}
-
-		"Healing"
-		{
-			"ControlName"		"CExLabel"
-			"fieldName"			"Healing"
-			"labelText"			"%healing%"
-			"xpos"				"35"
-			"ypos"				"0"
-			"wide"				"30"
-			"tall"				"20"
-			"visible"			"0"
-			"enabled"			"0"
-
-			"pin_to_sibling"		"HealingLabel"
-			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
-			"pin_to_sibling_corner"	"PIN_TOPRIGHT"
 		}
 		"Healing2"
 		{
-			"ControlName"		"CExLabel"
-			"fieldName"			"Healing2"
-			"font"				"FontRegular11"
-			"labelText"			"%healing%"
-			"textAlignment"		"west"
-			"xpos"				"0"
-			"ypos"				"0"
-			"zpos"				"3"
-			"wide"				"30"
-			"tall"				"20"
+			"ControlName"				"CExLabel"
+			"fieldName"					"Healing2"
+			"font"						"FontRegular11"
+			"labelText"					"%healing%"
+			"textAlignment"				"west"
+			"xpos"						"3"
+			"ypos"						"0"
+			"wide"						"35"
+			"tall"						"20"
 
-			"pin_to_sibling"		"Healing"
-			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
-			"pin_to_sibling_corner"	"PIN_TOPRIGHT"
+			"pin_to_sibling"			"HealingLabel"
+			"pin_corner_to_sibling"		"PIN_TOPLEFT"
+			"pin_to_sibling_corner"		"PIN_TOPRIGHT"
 
-			if_mvm
+			"if_mvm"
 			{
-				"visible"	"0"
+				"visible"		"0"
 			}
 		}
 
 		"InvulnLabel"
 		{
-			"ControlName"		"CExLabel"
-			"fieldName"			"InvulnLabel"
-			"font"				"FontRegular11"
-			"labelText"			"#TF_ScoreBoard_InvulnLabel"
-			"textAlignment"		"east"
-			"xpos"				"0"
-			"ypos"				"12"
-			"zpos"				"3"
-			"wide"				"50"
-			"tall"				"20"
-
+			"ControlName"			"CExLabel"
+			"fieldName"				"InvulnLabel"
+			"font"					"FontRegular11"
+			"labelText"				"#TF_ScoreBoard_InvulnLabel"
+			"textAlignment"			"east"
+			"xpos"					"0"
+			"ypos"					"-12"
+			"wide"					"50"
+			"tall"					"20"
 			"pin_to_sibling"		"HealingLabel"
-			"pin_corner_to_sibling"	"PIN_BOTTOMRIGHT"
-			"pin_to_sibling_corner"	"PIN_BOTTOMRIGHT"
 
-			if_mvm
+			"if_mvm"
 			{
-				"font"		"FontRegular10"
-				"ypos"		"25"
-				
-				"pin_to_sibling"		"AssistsLabel"
-				"pin_corner_to_sibling"	"PIN_BOTTOMRIGHT"
-				"pin_to_sibling_corner"	"PIN_BOTTOMRIGHT"			   						 				 
+				"font"						"FontRegular10"
+				"ypos"						"25"
+				"pin_to_sibling"			"BonusLabel"
 			}
-		}
-		"Invuln"
-		{
-			"ControlName"		"CExLabel"
-			"fieldName"			"Invuln"
-			"labelText"			"%invulns%"
-			"xpos"				"35"
-			"ypos"				"0"
-			"wide"				"30"
-			"tall"				"20"
-			"visible"			"0"
-			"enabled"			"0"
-
-			"pin_to_sibling"		"InvulnLabel"
-			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
-			"pin_to_sibling_corner"	"PIN_TOPRIGHT"
 		}
 		"Invuln2"
 		{
-			"ControlName"		"CExLabel"
-			"fieldName"			"Invuln2"
-			"font"				"FontRegular11"
-			"labelText"			"%invulns%"
-			"textAlignment"		"west"
-			"xpos"				"0"
-			"ypos"				"0"
-			"zpos"				"3"
-			"wide"				"30"
-			"tall"				"20"
+			"ControlName"				"CExLabel"
+			"fieldName"					"Invuln2"
+			"font"						"FontRegular11"
+			"labelText"					"%invulns%"
+			"textAlignment"				"west"
+			"xpos"						"3"
+			"ypos"						"0"
+			"wide"						"30"
+			"tall"						"20"
 
-			"pin_to_sibling"		"Invuln"
-			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
-			"pin_to_sibling_corner"	"PIN_TOPRIGHT"
+			"pin_to_sibling"			"InvulnLabel"
+			"pin_corner_to_sibling"		"PIN_TOPLEFT"
+			"pin_to_sibling_corner"		"PIN_TOPRIGHT"
 
-			if_mvm
-			{
-				"font"				"FontRegular10"
-			}
-		}
-
-		"TeleportsLabel"
-		{
-			"ControlName"		"CExLabel"
-			"fieldName"			"TeleportsLabel"
-			"font"				"FontRegular11"
-			"labelText"			"#TF_ScoreBoard_TeleportsLabel"
-			"textAlignment"		"east"
-			"xpos"				"0"
-			"ypos"				"12"
-			"zpos"				"3"
-			"wide"				"50"
-			"tall"				"20"
-
-			"pin_to_sibling"		"InvulnLabel"
-			"pin_corner_to_sibling"	"PIN_BOTTOMRIGHT"
-			"pin_to_sibling_corner"	"PIN_BOTTOMRIGHT"
-
-			if_mvm
-			{
-				"font"				"FontRegular10"
-				"xpos"				"0"
-				"ypos"				"50"
-				
-				"pin_to_sibling"		"AssistsLabel"
-				"pin_corner_to_sibling"	"PIN_BOTTOMRIGHT"
-				"pin_to_sibling_corner"	"PIN_BOTTOMRIGHT"
-			}
-		}
-		"Teleports"
-		{
-			"ControlName"		"CExLabel"
-			"fieldName"			"Teleports"
-			"labelText"			"%teleports%"
-			"xpos"				"35"
-			"ypos"				"0"
-			"wide"				"30"
-			"tall"				"20"
-			"visible"			"0"
-			"enabled"			"0"
-
-			"pin_to_sibling"		"TeleportsLabel"
-			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
-			"pin_to_sibling_corner"	"PIN_TOPRIGHT"
-		}
-		"Teleports2"
-		{
-			"ControlName"		"CExLabel"
-			"fieldName"			"Teleports2"
-			"font"				"FontRegular11"
-			"labelText"			"%teleports%"
-			"textAlignment"		"west"
-			"xpos"				"0"
-			"ypos"				"0"
-			"zpos"				"3"
-			"wide"				"30"
-			"tall"				"20"
-
-			"pin_to_sibling"		"Teleports"
-			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
-			"pin_to_sibling_corner"	"PIN_TOPRIGHT"
-
-			if_mvm
-			{
-				"font"			"FontRegular10"
-			}
-		}
-
-		"HeadshotsLabel"
-		{
-			"ControlName"		"CExLabel"
-			"fieldName"			"HeadshotsLabel"
-			"font"				"FontRegular11"
-			"labelText"			"#TF_ScoreBoard_HeadshotsLabel"
-			"textAlignment"		"east"
-			"xpos"				"80"
-			"ypos"				"0"
-			"zpos"				"3"
-			"wide"				"50"
-			"tall"				"20"
-
-			"pin_to_sibling"		"HealingLabel"
-			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
-			"pin_to_sibling_corner"	"PIN_TOPRIGHT"
-
-			if_mvm
-			{
-				"font"				"FontRegular10"
-				"xpos"				"90"
-				"ypos"				"0"
-				"wide"				"60"
-				
-				"pin_to_sibling"		"AssistsLabel"
-				"pin_corner_to_sibling"	"PIN_BOTTOMRIGHT"
-				"pin_to_sibling_corner"	"PIN_BOTTOMRIGHT"
-			}
-		}
-		"Headshots"
-		{
-			"ControlName"		"CExLabel"
-			"fieldName"			"Headshots"
-			"labelText"			"%headshots%"
-			"xpos"				"35"
-			"ypos"				"0"
-			"wide"				"30"
-			"tall"				"20"
-			"visible"			"0"
-			"enabled"			"0"
-
-			"pin_to_sibling"		"HeadshotsLabel"
-			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
-			"pin_to_sibling_corner"	"PIN_TOPRIGHT"
-		}
-		"Headshots2"
-		{
-			"ControlName"		"CExLabel"
-			"fieldName"			"Headshots2"
-			"font"				"FontRegular11"
-			"labelText"			"%headshots%"
-			"textAlignment"		"west"
-			"xpos"				"0"
-			"ypos"				"0"
-			"zpos"				"3"
-			"wide"				"30"
-			"tall"				"20"
-
-			"pin_to_sibling"		"Headshots"
-			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
-			"pin_to_sibling_corner"	"PIN_TOPRIGHT"
-
-			if_mvm
-			{
-				"font"				"FontRegular10"
-			}
-		}
-
-		"BackstabsLabel"
-		{
-			"ControlName"		"CExLabel"
-			"fieldName"			"BackstabsLabel"
-			"font"				"FontRegular11"
-			"labelText"			"#TF_ScoreBoard_BackstabsLabel"
-			"textAlignment"		"east"
-			"xpos"				"0"
-			"ypos"				"12"
-			"zpos"				"3"
-			"wide"				"50"
-			"tall"				"20"
-
-			"pin_to_sibling"		"HeadshotsLabel"
-			"pin_corner_to_sibling"	"PIN_BOTTOMRIGHT"
-			"pin_to_sibling_corner"	"PIN_BOTTOMRIGHT"
-
-			if_mvm
+			"if_mvm"
 			{
 				"font"		"FontRegular10"
-				"xpos"		"90"
-				"ypos"		"0"
-				
-				"pin_to_sibling"		"HeadshotsLabel"
-				"pin_corner_to_sibling"	"PIN_BOTTOMRIGHT"
-				"pin_to_sibling_corner"	"PIN_BOTTOMRIGHT"		 
-			}
-		}
-		"Backstabs"
-		{
-			"ControlName"		"CExLabel"
-			"fieldName"			"Backstabs"
-			"labelText"			"%backstabs%"
-			"xpos"				"35"
-			"zpos"				"3"
-			"wide"				"30"
-			"tall"				"20"
-			"visible"			"0"
-			"enabled"			"0"
-
-			"pin_to_sibling"		"BackstabsLabel"
-			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
-			"pin_to_sibling_corner"	"PIN_TOPRIGHT"
-		}
-		"Backstabs2"
-		{
-			"ControlName"		"CExLabel"
-			"fieldName"			"Backstabs2"
-			"font"				"FontRegular11"
-			"labelText"			"%backstabs%"
-			"textAlignment"		"west"
-			"xpos"				"0"
-			"ypos"				"0"
-			"zpos"				"3"
-			"wide"				"30"
-			"tall"				"20"
-
-			"pin_to_sibling"		"Backstabs"
-			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
-			"pin_to_sibling_corner"	"PIN_TOPRIGHT"
-
-			if_mvm
-			{
-				"font"				"FontRegular10"
+				"xpos"						"0"
+				"ypos"						"25"
+				"pin_to_sibling"			"Bonus2"
+				"pin_to_sibling_corner"		"PIN_TOPLEFT"
 			}
 		}
 
 		"BonusLabel"
 		{
-			"ControlName"		"CExLabel"
-			"fieldName"			"BonusLabel"
-			"font"				"FontRegular11"
-			"labelText"			"#TF_ScoreBoard_BonusLabel"
-			"textAlignment"		"east"
-			"xpos"				"0"
-			"ypos"				"12"
-			"zpos"				"3"
-			"wide"				"50"
-			"tall"				"20"
+			"ControlName"			"CExLabel"
+			"fieldName"				"BonusLabel"
+			"font"					"FontRegular11"
+			"labelText"				"#TF_ScoreBoard_BonusLabel"
+			"textAlignment"			"east"
+			"xpos"					"0"
+			"ypos"					"-12"
+			"wide"					"50"
+			"tall"					"20"
+			"pin_to_sibling"		"InvulnLabel"
 
-			"pin_to_sibling"		"BackstabsLabel"
-			"pin_corner_to_sibling"	"PIN_BOTTOMRIGHT"
-			"pin_to_sibling_corner"	"PIN_BOTTOMRIGHT"
-
-			if_mvm
+			"if_mvm"
 			{
-				"font"				"FontRegular10"
-				"xpos"				"0"
-				"ypos"				"25"
-				
-				"pin_to_sibling"		"BackstabsLabel"
-				"pin_corner_to_sibling"	"PIN_BOTTOMRIGHT"
-				"pin_to_sibling_corner"	"PIN_BOTTOMRIGHT"
+				"font"		"FontRegular10"
+				"xpos"		"53"
+				"ypos"		"0"
+				"pin_to_sibling"		"Bonus2"
 			}
-		}
-		"Bonus"
-		{
-			"ControlName"		"CExLabel"
-			"fieldName"			"Bonus"
-			"labelText"			"%bonus%"
-			"xpos"				"35"
-			"ypos"				"0"
-			"wide"				"30"
-			"tall"				"20"
-			"visible"			"0"
-			"enabled"			"0"
-
-			"pin_to_sibling"		"BonusLabel"
-			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
-			"pin_to_sibling_corner"	"PIN_TOPRIGHT"
 		}
 		"Bonus2"
 		{
-			"ControlName"		"CExLabel"
-			"fieldName"			"Bonus2"
-			"font"				"FontRegular11"
-			"labelText"			"%bonus%"
-			"textAlignment"		"west"
-			"xpos"				"0"
-			"ypos"				"0"
-			"zpos"				"3"
-			"wide"				"30"
-			"tall"				"20"
+			"ControlName"				"CExLabel"
+			"fieldName"					"Bonus2"
+			"font"						"FontRegular11"
+			"labelText"					"%bonus%"
+			"textAlignment"				"west"
+			"xpos"						"3"
+			"ypos"						"0"
+			"wide"						"30"
+			"tall"						"20"
 
-			"pin_to_sibling"		"Bonus"
-			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
-			"pin_to_sibling_corner"	"PIN_TOPRIGHT"
+			"pin_to_sibling"			"BonusLabel"
+			"pin_corner_to_sibling"		"PIN_TOPLEFT"
+			"pin_to_sibling_corner"		"PIN_TOPRIGHT"
 
-			if_mvm
+			"if_mvm"
 			{
-				"font"				"FontRegular10"
+				"xpos"						"226"
+				"ypos"						"75"
+				"font"					"FontRegular10"
+				"pin_to_sibling"			""
+			}
+		}
+
+		"HeadshotsLabel"
+		{
+			"ControlName"			"CExLabel"
+			"fieldName"				"HeadshotsLabel"
+			"font"					"FontRegular11"
+			"labelText"				"#TF_ScoreBoard_HeadshotsLabel"
+			"textAlignment"			"east"
+			"xpos"					"-75"
+			"ypos"					"0"
+			"wide"					"60"
+			"tall"					"20"
+			"pin_to_sibling"		"HealingLabel"
+
+			"if_mvm"
+			{
+				"font"					"FontRegular10"
+				"xpos"					"-86"
+				"pin_to_sibling"		"AssistsLabel"
+			}
+		}
+		"Headshots2"
+		{
+			"ControlName"				"CExLabel"
+			"fieldName"					"Headshots2"
+			"font"						"FontRegular11"
+			"labelText"					"%headshots%"
+			"textAlignment"				"west"
+			"xpos"						"3"
+			"ypos"						"0"
+			"wide"						"30"
+			"tall"						"20"
+
+			"pin_to_sibling"			"HeadshotsLabel"
+			"pin_corner_to_sibling"		"PIN_TOPLEFT"
+			"pin_to_sibling_corner"		"PIN_TOPRIGHT"
+
+			"if_mvm"
+			{
+				"font"		"FontRegular10"
+			}
+		}
+
+		"BackstabsLabel"
+		{
+			"ControlName"			"CExLabel"
+			"fieldName"				"BackstabsLabel"
+			"font"					"FontRegular11"
+			"labelText"				"#TF_ScoreBoard_BackstabsLabel"
+			"textAlignment"			"east"
+			"xpos"					"0"
+			"ypos"					"-12"
+			"wide"					"60"
+			"tall"					"20"
+			"pin_to_sibling"		"HeadshotsLabel"
+
+			"if_mvm"
+			{
+				"font"						"FontRegular10"
+				"ypos"						"-25"
+				"pin_to_sibling"			"HeadshotsLabel"
+			}
+		}
+		"Backstabs2"
+		{
+			"ControlName"				"CExLabel"
+			"fieldName"					"Backstabs2"
+			"font"						"FontRegular11"
+			"labelText"					"%backstabs%"
+			"textAlignment"				"west"
+			"xpos"						"3"
+			"ypos"						"0"
+			"wide"						"30"
+			"tall"						"20"
+
+			"pin_to_sibling"			"BackstabsLabel"
+			"pin_corner_to_sibling"		"PIN_TOPLEFT"
+			"pin_to_sibling_corner"		"PIN_TOPRIGHT"
+
+			"if_mvm"
+			{
+				"font"		"FontRegular10"
+			}
+		}
+
+		"TeleportsLabel"
+		{
+			"ControlName"			"CExLabel"
+			"fieldName"				"TeleportsLabel"
+			"font"					"FontRegular11"
+			"labelText"				"#TF_ScoreBoard_TeleportsLabel"
+			"textAlignment"			"east"
+			"xpos"					"0"
+			"ypos"					"-12"
+			"wide"					"60"
+			"tall"					"20"
+			"pin_to_sibling"		"BackstabsLabel"
+
+			"if_mvm"
+			{
+				"font"					"FontRegular10"
+				"ypos"					"-50"
+				"pin_to_sibling"		"AssistsLabel"
+			}
+		}
+		"Teleports2"
+		{
+			"ControlName"				"CExLabel"
+			"fieldName"					"Teleports2"
+			"font"						"FontRegular11"
+			"labelText"					"%teleports%"
+			"textAlignment"				"west"
+			"xpos"						"3"
+			"ypos"						"0"
+			"wide"						"30"
+			"tall"						"20"
+
+			"pin_to_sibling"			"TeleportsLabel"
+			"pin_corner_to_sibling"		"PIN_TOPLEFT"
+			"pin_to_sibling_corner"		"PIN_TOPRIGHT"
+
+			"if_mvm"
+			{
+				"font"		"FontRegular10"
 			}
 		}
 
 		"SupportLabel"
 		{
-			"ControlName"		"CExLabel"
-			"fieldName"			"SupportLabel"
-			"font"				"FontRegular11"
-			"labelText"			"#TF_Scoreboard_Support"
-			"textAlignment"		"east"
-			"xpos"				"80"
-			"ypos"				"0"
-			"zpos"				"3"
-			"wide"				"50"
-			"tall"				"20"
-
+			"ControlName"			"CExLabel"
+			"fieldName"				"SupportLabel"
+			"font"					"FontRegular11"
+			"labelText"				"#TF_Scoreboard_Support"
+			"textAlignment"			"east"
+			"xpos"					"-80"
+			"ypos"					"0"
+			"wide"					"60"
+			"tall"					"20"
 			"pin_to_sibling"		"HeadshotsLabel"
-			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
-			"pin_to_sibling_corner"	"PIN_TOPRIGHT"
-
-			if_mvm
+			
+			"if_mvm"
 			{
-				"font"			"FontRegular10"
-				"xpos"			"0"
-				"ypos"			"20"
-				"visible"		"0"
-				
-				"pin_to_sibling"		"BonusLabel"
-				"pin_corner_to_sibling"	"PIN_BOTTOMRIGHT"
-				"pin_to_sibling_corner"	"PIN_BOTTOMRIGHT"
+				"visible"					"0"
 			}
-		}
-		"Support"
-		{
-			"ControlName"		"CExLabel"
-			"fieldName"			"Support"
-			"labelText"			"%support%"
-			"xpos"				"35"
-			"ypos"				"0"
-			"wide"				"30"
-			"tall"				"20"
-			"visible"			"0"
-			"enabled"			"0"
-
-			"pin_to_sibling"		"SupportLabel"
-			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
-			"pin_to_sibling_corner"	"PIN_TOPRIGHT"
 		}
 		"Support2"
 		{
-			"ControlName"		"CExLabel"
-			"fieldName"			"Support2"
-			"font"				"FontRegular11"
-			"labelText"			"%support%"
-			"textAlignment"		"west"
-			"xpos"				"0"
-			"ypos"				"0"
-			"zpos"				"3"
-			"wide"				"30"
-			"tall"				"20"
+			"ControlName"				"CExLabel"
+			"fieldName"					"Support2"
+			"font"						"FontRegular11"
+			"labelText"					"%support%"
+			"textAlignment"				"west"
+			"xpos"						"3"
+			"ypos"						"0"
+			"wide"						"30"
+			"tall"						"20"
 
-			"pin_to_sibling"		"Support"
-			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
-			"pin_to_sibling_corner"	"PIN_TOPRIGHT"
-
-			if_mvm
+			"pin_to_sibling"			"SupportLabel"
+			"pin_corner_to_sibling"		"PIN_TOPLEFT"
+			"pin_to_sibling_corner"		"PIN_TOPRIGHT"
+			
+			"if_mvm"
 			{
-				"visible"	"0"
+				"visible"		"0"
 			}
 		}
 
 		"DamageLabel"
 		{
-			"ControlName"		"CExLabel"
-			"fieldName"			"DamageLabel"
-			"font"				"FontRegular11"
-			"labelText"			"#TF_Scoreboard_Damage"
-			"textAlignment"		"east"
-			"xpos"				"0"
-			"ypos"				"12"
-			"zpos"				"3"
-			"wide"				"50"
-			"tall"				"20"
+			"ControlName"				"CExLabel"
+			"fieldName"					"DamageLabel"
+			"font"						"FontRegular11"
+			"labelText"					"#TF_Scoreboard_Damage"
+			"textAlignment"				"east"
+			"xpos"						"0"
+			"ypos"						"-12"
+			"wide"						"60"
+			"tall"						"20"
+			"pin_to_sibling"			"SupportLabel"
 
-			"pin_to_sibling"		"SupportLabel"
-			"pin_corner_to_sibling"	"PIN_BOTTOMRIGHT"
-			"pin_to_sibling_corner"	"PIN_BOTTOMRIGHT"
-
-			if_mvm
+			"if_mvm"
 			{
-				"visible"	"0"
+				"visible"		"0"
 			}
-		}
-		"Damage"
-		{
-			"ControlName"		"CExLabel"
-			"fieldName"			"Damage"
-			"labelText"			"%damage%"
-			"xpos"				"35"
-			"ypos"				"0"
-			"wide"				"30"
-			"tall"				"20"
-			"visible"			"0"
-			"enabled"			"0"
-
-			"pin_to_sibling"		"DamageLabel"
-			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
-			"pin_to_sibling_corner"	"PIN_TOPRIGHT"
 		}
 		"Damage2"
 		{
-			"ControlName"		"CExLabel"
-			"fieldName"			"Damage2"
-			"font"				"FontRegular11"
-			"labelText"			"%damage%"
-			"textAlignment"		"west"
-			"xpos"				"0"
-			"ypos"				"0"
-			"zpos"				"3"
-			"wide"				"30"
-			"tall"				"20"
-			"pin_to_sibling"		"Damage"
+			"ControlName"				"CExLabel"
+			"fieldName"					"Damage2"
+			"font"						"FontRegular11"
+			"labelText"					"%damage%"
+			"textAlignment"				"west"
+			"xpos"						"3"
+			"ypos"						"0"
+			"wide"						"50"
+			"tall"						"20"
 
-			if_mvm
+			"pin_to_sibling"			"DamageLabel"
+			"pin_corner_to_sibling"		"PIN_TOPLEFT"
+			"pin_to_sibling_corner"		"PIN_TOPRIGHT"
+			
+			"if_mvm"
 			{
-				"visible"	"0"
+				"visible"		"0"
 			}
 		}
+
 		"MvmLossLabel"
 		{
-			"ControlName"		"CExLabel"
-			"fieldName"			"MvmLossLabel"
-			"font"				"FontRegular10"
-			"labelText"			"#TF_Competitive_MatchHistory_Loss"
-			"textAlignment"		"east"
-			"xpos"				"1"
-			"ypos"				"-25"
-			"zpos"				"3"
-			"wide"				"50"
-			"tall"				"20"
-			"visible"			"0"
-			"enabled"			"0"
-			"fgcolor"			"DisguiseMenuIconBlue"
-
+			"ControlName"			"CExLabel"
+			"fieldName"				"MvmLossLabel"
+			"font"					"FontRegular10"
+			"labelText"				"#TF_Competitive_MatchHistory_Loss"
+			"textAlignment"			"east"
+			"xpos"					"0"
+			"ypos"					"-25"
+			"wide"					"50"
+			"tall"					"20"
+			"TextInsetX"			"3"
+			"visible"				"0"
+			"fgcolor"				"DisguiseMenuIconBlue"
 			"pin_to_sibling"		"BonusLabel"
-			"pin_corner_to_sibling"	"PIN_TOPLEFT"
-			"pin_to_sibling_corner"	"PIN_TOPLEFT"
-
-			if_mvm
+			
+			"if_mvm"
 			{
-				"visible"			"1"
-				"enabled"			"1"
+				"visible"		"1"
 			}
 		}
 		"MvmLossLabelColon"
 		{
-			"ControlName"		"CExLabel"
-			"fieldName"			"MvmLossLabelColon"
-			"font"				"FontRegular10"
-			"labelText"			":"
-			"textAlignment"		"west"
-			"xpos"				"0"
-			"ypos"				"0"
-			"zpos"				"3"
-			"wide"				"50"
-			"tall"				"20"
-			"visible"			"0"
-			"enabled"			"0"
-			"fgcolor"			"DisguiseMenuIconBlue"
-
+			"ControlName"			"CExLabel"
+			"fieldName"				"MvmLossLabelColon"
+			"font"					"FontRegular10"
+			"labelText"				":"
+			"textAlignment"			"east"
+			"xpos"					"0"
+			"ypos"					"0"
+			"wide"					"50"
+			"tall"					"20"
+			"visible"				"0"
+			"fgcolor"				"DisguiseMenuIconBlue"
 			"pin_to_sibling"		"MvmLossLabel"
-			"pin_corner_to_sibling"	"PIN_TOPLEFT"
-			"pin_to_sibling_corner"	"PIN_TOPRIGHT"
-
-			if_mvm
+			
+			"if_mvm"
 			{
-				"visible"			"1"
-				"enabled"			"1"
+				"visible"		"1"
 			}
 		}
 	}

--- a/resource/ui/scoreboard.res
+++ b/resource/ui/scoreboard.res
@@ -423,6 +423,7 @@
 		"wrap"				"1"
 		"xpos"				"-2"
 		"ypos"				"1"
+		"zpos"				"-1"
 		"wide"				"370"
 		"wide_minmode"		"0"
 		"tall"				"22"
@@ -457,12 +458,12 @@
 		if_mvm
 		{
 			"xpos"				"3"
-			"ypos"				"166"
+			"ypos"				"-181"
 			"wide"				"270"
 			"tall"				"132"
 			"pin_to_sibling"		"mapname"
 			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
-			"pin_to_sibling_corner"	"PIN_BOTTOMRIGHT"
+			"pin_to_sibling_corner"	"PIN_TOPRIGHT"
 		}
 	}
 
@@ -475,6 +476,7 @@
 		"textAlignment"		"north-west"
 		"xpos"				"-2"
 		"ypos"				"-72"
+		"zpos"				"-1"
 		"wide"				"577"
 		"wide_minmode"		"0"
 		"tall"				"20"
@@ -490,21 +492,12 @@
 	{
 		"ControlName"		"ImagePanel"
 		"fieldName"			"ClassImage"
-		"xpos"				"0"
-		"ypos"				"-5"
-		"wide"				"45"
-		"tall"				"45"
+		"xpos"				"25"
+		"ypos"				"r75"
+		"wide"				"75"
+		"tall"				"75"
 		"image"				"../hud/class_scoutred"
 		"scaleImage"		"1"
-
-		"pin_to_sibling"		"StatsBG"
-		"pin_corner_to_sibling"	"PIN_TOPRIGHT"
-		"pin_to_sibling_corner"	"PIN_TOPRIGHT"
-
-		if_mvm
-		{
-			"xpos"				"9999"
-		}
 	}
 	
 	"classmodelpanel"
@@ -513,6 +506,7 @@
 		"fieldName"			"classmodelpanel"
 		"xpos"				"0"
 		"ypos"				"r200"
+		"zpos"				"-1"
 		"wide"				"150"
 		"tall"				"200"
 		"fov"				"23"
@@ -570,6 +564,7 @@
 		"textAlignment"		"north-east"
 		"xpos"				"-2"
 		"ypos"				"1"
+		"zpos"				"-1"
 		"wide"				"210"
 		"tall"				"15"
 		"allcaps"			"1"
@@ -1162,13 +1157,7 @@
 			
 			"if_mvm"
 			{
-				"font"						"FontRegular10"
-				"xpos"						"0"
-				"ypos"						"20"
-				"visible"					"0"
-				"pin_to_sibling"			"AssistsLabel"
-				"pin_corner_to_sibling"		"PIN_BOTTOMRIGHT"
-				"pin_to_sibling_corner"		"PIN_BOTTOMRIGHT"
+				"visible"		"0"
 			}
 		}
 		"Healing2"
@@ -1426,7 +1415,7 @@
 			
 			"if_mvm"
 			{
-				"visible"					"0"
+				"visible"			"0"
 			}
 		}
 		"Support2"
@@ -1550,124 +1539,49 @@
 			"visible"		"1"
 		}
 	}
-	
-	"DrawingBoardDown"
+
+	"DrawingBoardLeft"
 	{
 		"ControlName"	"EditablePanel"
 		"xpos"			"0"
-		"ypos"			"0"
-		"zpos"			"1000"
+		"ypos"			"-70"
+		"zpos"			"-1"
 		"wide"			"f0"
 		"tall"			"f0"
-		"visible"		"1"
-		"paintBorder"	"1"
-		"border"		"NoBorder"
-		"proportionaltoparent"	"1"
 		
-		"pin_to_sibling"			"StatsBG"
-		"pin_corner_to_sibling"		"PIN_TOPLEFT"
-		"pin_to_sibling_corner"		"PIN_BOTTOMLEFT"
+		"pin_to_sibling"			"classmodelpanel"
+		"pin_corner_to_sibling"		"PIN_BOTTOMLEFT" 
+		"pin_to_sibling_corner"		"PIN_TOPLEFT"
 		
 		"Draw"
 		{
 			"ControlName"		"CDrawingPanel"
-			"xpos"				"0"
-			"ypos"				"0"
 			"wide"				"f0"
 			"tall"				"f0"
 			"linecolor"			"TanLight"
-			"bgcolor_override"	"Transparent"
-			"proportionaltoparent"	"1"
-		}
-	}
-	
-	"DrawingBoardTop"
-	{
-		"ControlName"	"EditablePanel"
-		"xpos"			"0"
-		"ypos"			"0"
-		"zpos"			"1000"
-		"wide"			"f0"
-		"tall"			"f0"
-		"visible"		"1"
-		"paintBorder"	"1"
-		"border"		"NoBorder"
-		"proportionaltoparent"	"1"
-		
-		"pin_to_sibling"			"RedBG"
-		"pin_corner_to_sibling"		"PIN_BOTTOMRIGHT"
-		"pin_to_sibling_corner"		"PIN_TOPRIGHT"
-		
-		"Draw"
-		{
-			"ControlName"		"CDrawingPanel"
-			"xpos"				"0"
-			"ypos"				"0"
-			"wide"				"f0"
-			"tall"				"f0"
-			"linecolor"			"TanLight"
-			"bgcolor_override"	"Transparent"
-			"proportionaltoparent"	"1"
 		}
 	}
 	
 	"DrawingBoardRight"
 	{
 		"ControlName"	"EditablePanel"
-		"xpos"			"0"
+		"xpos"			"c-290"
 		"ypos"			"0"
-		"zpos"			"1000"
+		"zpos"			"-1"
 		"wide"			"f0"
 		"tall"			"f0"
-		"visible"		"1"
-		"paintBorder"	"1"
-		"border"		"NoBorder"
-		"proportionaltoparent"	"1"
-		
-		"pin_to_sibling"			"StatsBG"
-		"pin_corner_to_sibling"		"PIN_BOTTOMLEFT"
-		"pin_to_sibling_corner"		"PIN_BOTTOMRIGHT"
 		
 		"Draw"
 		{
 			"ControlName"		"CDrawingPanel"
-			"xpos"				"0"
-			"ypos"				"0"
 			"wide"				"f0"
 			"tall"				"f0"
 			"linecolor"			"TanLight"
-			"bgcolor_override"	"Transparent"
-			"proportionaltoparent"	"1"
 		}
-	}
-	
-	"DrawingBoardLeft"
-	{
-		"ControlName"	"EditablePanel"
-		"xpos"			"0"
-		"ypos"			"0"
-		"zpos"			"1000"
-		"wide"			"f0"
-		"tall"			"f0"
-		"visible"		"1"
-		"paintBorder"	"1"
-		"border"		"NoBorder"
-		"proportionaltoparent"	"1"
-		
-		"pin_to_sibling"			"classmodelpanel"
-		"pin_corner_to_sibling"		"PIN_BOTTOMRIGHT"
-		"pin_to_sibling_corner"		"PIN_TOPRIGHT"
-		
-		"Draw"
+
+		if_mvm
 		{
-			"ControlName"		"CDrawingPanel"
-			"xpos"				"0"
-			"ypos"				"0"
-			"wide"				"f0"
-			"tall"				"f0"
-			"linecolor"			"TanLight"
-			"bgcolor_override"	"Transparent"
-			"proportionaltoparent"	"1"
+			"zpos"			"999"
 		}
 	}
 }

--- a/resource/ui/scoreboard.res
+++ b/resource/ui/scoreboard.res
@@ -8,10 +8,6 @@
 		"ypos"				"31"
 		"wide"				"f0"
 		"tall"				"f0"
-		"autoResize"		"0"
-		"pinCorner"			"0"
-		"visible"			"1"
-		"enabled"			"1"
 		"tabPosition"		"0"
 		"medal_width"		"25"
 		"medal_column_width" "25"
@@ -36,12 +32,6 @@
 		"zpos"				"1"
 		"wide"				"2"
 		"tall"				"35"
-		"autoResize"		"0"
-		"pinCorner"			"0"
-		"visible"			"1"
-		"enabled"			"1"
-		"pinCorner"			"0"
-		"autoResize"		"0"
 		"PaintBackgroundType"	"0"
 		"paintbackground"		"1"
 		"bgcolor_override"		"BlueTeam"
@@ -65,8 +55,6 @@
 		"zpos"				"-1"
 		"wide"				"290"
 		"tall"				"35"
-		"visible"			"1"
-		"enabled"			"1"
 		"bgcolor_override"	"HudBlack"
 		"PaintBackgroundType"	"2"
 		
@@ -86,8 +74,6 @@
 		"wide"				"290"
 		"wide_minmode"		"0"
 		"tall"				"210"
-		"visible"			"1"
-		"enabled"			"1"
 		"bgcolor_override"	"25 25 25 200"
 		"PaintBackgroundType"	"2"
 
@@ -112,10 +98,6 @@
 		"ypos"				"0"
 		"wide"				"250"
 		"tall"				"22"
-		"autoResize"		"0"
-		"pinCorner"			"0"
-		"visible"			"1"
-		"enabled"			"1"
 		"fgcolor"			"BlueTeam"
 		"TextInsetX"		"15"
 
@@ -141,10 +123,6 @@
 		"zpos"				"4"
 		"wide"				"80"
 		"tall"				"35"
-		"autoResize"		"0"
-		"pinCorner"			"0"
-		"visible"			"1"
-		"enabled"			"1"
 		"fgcolor"			"BlueTeam"
 		"TextInsetX"		"20"
 
@@ -176,10 +154,6 @@
 		"ypos"				"0"
 		"wide"				"210"
 		"tall"				"12"
-		"autoResize"		"0"
-		"pinCorner"			"0"
-		"visible"			"1"
-		"enabled"			"1"
 		"fgcolor"			"BlueTeam"
 		"TextInsetX"		"15"
 
@@ -202,12 +176,6 @@
 		"zpos"				"1"
 		"wide"				"2"
 		"tall"				"35"
-		"autoResize"		"0"
-		"pinCorner"			"0"
-		"visible"			"1"
-		"enabled"			"1"
-		"pinCorner"			"0"
-		"autoResize"		"0"
 		"PaintBackgroundType"	"0"
 		"paintbackground"		"1"
 		"bgcolor_override"		"RedTeam"
@@ -231,8 +199,6 @@
 		"zpos"				"-1"
 		"wide"				"290"
 		"tall"				"35"
-		"visible"			"1"
-		"enabled"			"1"
 		"bgcolor_override"	"HudBlack"
 		"PaintBackgroundType"	"2"
 
@@ -255,8 +221,6 @@
 		"wide"				"290"
 		"wide_minmode"		"0"
 		"tall"				"210"
-		"visible"			"1"
-		"enabled"			"1"
 		"bgcolor_override"	"25 25 25 200"
 		"PaintBackgroundType"	"2"
 
@@ -281,10 +245,6 @@
 		"ypos"				"0"
 		"wide"				"250"
 		"tall"				"22"
-		"autoResize"		"0"
-		"pinCorner"			"0"
-		"visible"			"1"
-		"enabled"			"1"
 		"fgcolor"			"RedTeam"
 		"TextInsetX"		"15"
 
@@ -310,10 +270,6 @@
 		"zpos"				"4"
 		"wide"				"80"
 		"tall"				"35"
-		"autoResize"		"0"
-		"pinCorner"			"0"
-		"visible"			"1"
-		"enabled"			"1"
 		"fgcolor"			"RedTeam"
 		"TextInsetX"		"23"
 
@@ -338,10 +294,6 @@
 		"ypos"				"0"
 		"wide"				"210"
 		"tall"				"12"
-		"autoResize"		"0"
-		"pinCorner"			"0"
-		"visible"			"1"
-		"enabled"			"1"
 		"fgcolor"			"RedTeam"
 		"TextInsetX"		"20"
 
@@ -364,8 +316,6 @@
 		"zpos"				"-1"
 		"wide"				"290"
 		"tall"				"11"
-		"visible"			"1"
-		"enabled"			"1"
 		"bgcolor_override"	"25 25 25 200"
 		"PaintBackgroundType"	"2"
 
@@ -393,10 +343,6 @@
 		"wide"				"280"
 		"wide_minmode"		"0"
 		"tall"				"11"
-		"autoResize"		"0"
-		"pinCorner"			"0"
-		"visible"			"1"
-		"enabled"			"1"
 
 		"pin_to_sibling"		"ServerBackground"
 		"pin_corner_to_sibling"	"PIN_TOPLEFT"
@@ -417,8 +363,6 @@
 		"zpos"				"-1"
 		"wide"				"290"
 		"tall"				"11"
-		"visible"			"1"
-		"enabled"			"1"
 		"bgcolor_override"	"25 25 25 200"
 		"PaintBackgroundType"	"2"
 
@@ -443,10 +387,6 @@
 		"zpos"				"2"
 		"wide"				"290"
 		"tall"				"11"
-		"autoResize"		"0"
-		"pinCorner"			"0"
-		"visible"			"1"
-		"enabled"			"1"
 
 		"pin_to_sibling"		"ServerTimeBackground"
 		"pin_corner_to_sibling"	"PIN_TOPRIGHT"
@@ -468,9 +408,6 @@
 		"wide"				"288"
 		"tall"				"204"
 		"wide_minmode"		"0"
-		"pinCorner"			"0"
-		"visible"			"1"
-		"enabled"			"1"
 		"tabPosition"		"0"
 		"autoresize"		"3"
 		"linespacing"		"16"
@@ -481,6 +418,7 @@
 			"visible"			"0"
 		}
 	}
+
 	"RedPlayerList"
 	{
 		"ControlName"		"SectionedListPanel"
@@ -491,9 +429,6 @@
 		"wide"				"288"
 		"tall"				"204"
 		"wide_minmode"		"0"
-		"pinCorner"			"0"
-		"visible"			"1"
-		"enabled"			"1"
 		"tabPosition"		"0"
 		"autoresize"		"3"
 		"linespacing"		"16"
@@ -504,6 +439,7 @@
 			"visible"			"0"
 		}
 	}
+
 	"Spectators"
 	{
 		"ControlName"		"CExLabel"
@@ -517,10 +453,6 @@
 		"wide"				"577"
 		"wide_minmode"		"0"
 		"tall"				"15"
-		"autoResize"		"0"
-		"pinCorner"			"0"
-		"visible"			"1"
-		"enabled"			"1"
 
 		"pin_to_sibling"		"StatsBG"
 		"pin_corner_to_sibling"	"PIN_TOPLEFT"
@@ -542,8 +474,6 @@
 		"zpos"				"2"
 		"wide"				"581"
 		"tall"				"50"
-		"visible"			"1"
-		"enabled"			"1"
 		"bgcolor_override"	"25 25 25 200"
 		"PaintBackgroundType"	"2"
 
@@ -562,6 +492,7 @@
 			"pin_to_sibling_corner"	"PIN_BOTTOMRIGHT"
 		}
 	}
+
 	"SpectatorsInQueue"
 	{
 		"ControlName"		"CExLabel"
@@ -575,10 +506,6 @@
 		"wide"				"577"
 		"wide_minmode"		"0"
 		"tall"				"20"
-		"autoResize"		"0"
-		"pinCorner"			"0"
-		"visible"			"1"
-		"enabled"			"1"
 
 		"pin_to_sibling"		"StatsBG"
 		"pin_corner_to_sibling"	"PIN_BOTTOMLEFT"
@@ -599,8 +526,6 @@
 		"zpos"				"3"
 		"wide"				"45"
 		"tall"				"45"
-		"visible"			"1"
-		"enabled"			"1"
 		"image"				"../hud/class_scoutred"
 		"scaleImage"		"1"
 
@@ -623,10 +548,6 @@
 		"zpos"				"2"
 		"wide"				"150"
 		"tall"				"200"
-		"autoResize"		"0"
-		"pinCorner"			"0"
-		"visible"			"1"
-		"enabled"			"1"
 		"fov"				"23"
 		"allow_rot"			"1"
 		"render_texture"	"0"
@@ -652,36 +573,15 @@
 	{
 		"ControlName"		"EditablePanel"
 		"fieldName"			"PlayerNameBG"
-		"xpos"				"0"
-		"ypos"				"0"
-		"zpos"				"0"
 		"wide"				"0"
-		"tall"				"0"
-		"autoResize"		"0"
-		"pinCorner"			"0"
-		"visible"			"1"
-		"enabled"			"1"
-		"border"			"TFThinLineBorder"
-
-		if_mvm
-		{
-			"visible"			"0"
-		}
+		"visible"			"0"
+		"enabled"			"0"
 	}
 	"PlayerNameLabel"
 	{
 		"ControlName"		"CExLabel"
 		"fieldName"			"PlayerNameLabel"
-		"font"				"FontRegular11"
-		"labelText"			"%playername%"
-		"textAlignment"		"west"
-		"xpos"				"0"
-		"ypos"				"0"
-		"zpos"				"0"
 		"wide"				"0"
-		"tall"				"0"
-		"autoResize"		"0"
-		"pinCorner"			"0"
 		"visible"			"0"
 		"enabled"			"0"
 	}
@@ -690,16 +590,7 @@
 	{
 		"ControlName"		"CExLabel"
 		"fieldName"			"ServerLabelNew"
-		"font"				"ScoreboardVerySmall"
-		"labelText"			"%server%"
-		"textAlignment"		"east"
-		"xpos"				"0"
-		"ypos"				"0"
-		"zpos"				"0"
 		"wide"				"0"
-		"tall"				"0"
-		"autoResize"		"0"
-		"pinCorner"			"0"
 		"visible"			"0"
 		"enabled"			"0"
 	}
@@ -715,11 +606,6 @@
 		"zpos"				"5"
 		"wide"				"100"
 		"tall"				"15"
-		"autoResize"		"0"
-		"pinCorner"			"0"
-		"visible"			"1"
-		"enabled"			"1"
-		"fgcolor"			"TanLight"
 		"allcaps"			"1"
 
 		"pin_to_sibling"		"StatsBG"
@@ -742,34 +628,17 @@
 	{
 		"ControlName"		"ImagePanel"
 		"fieldName"			"HorizontalLine"
-		"xpos"				"115"
-		"ypos"				"367"
 		"zpos"				"3"
 		"wide"				"0"
-		"tall"				"0"
-		"autoResize"		"0"
-		"pinCorner"			"0"
 		"visible"			"0"
 		"enabled"			"0"
-		"tabPosition"		"0"
-		"fillcolor"			"127 127 127 153"
-		"PaintBackgroundType"	"0"
 	}
 
 	"PlayerScoreLabel"
 	{
 		"ControlName"		"CExLabel"
 		"fieldName"			"PlayerScoreLabel"
-		"font"				"ScoreboardMedium"
-		"labelText"			"%playerscore%"
-		"textAlignment"		"east"
-		"xpos"				"5"
-		"ypos"				"295"
-		"zpos"				"3"
-		"wide"				"140"
-		"tall"				"20"
-		"autoResize"		"0"
-		"pinCorner"			"0"
+		"wide"				"0"
 		"visible"			"0"
 		"enabled"			"0"
 	}
@@ -783,10 +652,6 @@
 		"zpos"				"3"
 		"wide"				"585"
 		"tall"				"50"
-		"autoResize"		"0"
-		"pinCorner"			"0"
-		"visible"			"1"
-		"enabled"			"1"
 		"pin_to_sibling"	"StatsBG"
 
 		if_mvm
@@ -995,10 +860,6 @@
 		"zpos"				"3"
 		"wide"				"585"
 		"tall"				"50"
-		"autoResize"		"0"
-		"pinCorner"			"0"
-		"visible"			"1"
-		"enabled"			"1"
 		"pin_to_sibling"	"StatsBG"
 
 		if_mvm
@@ -1019,11 +880,6 @@
 			"zpos"				"3"
 			"wide"				"20"
 			"tall"				"50"
-			"autoResize"		"0"
-			"pinCorner"			"0"
-			"visible"			"1"
-			"enabled"			"1"
-			"fgcolor"			"TanLight"
 
 			"pin_to_sibling"		"StatsBG"
 			"pin_corner_to_sibling"	"PIN_TOPLEFT"
@@ -1039,16 +895,11 @@
 		{
 			"ControlName"		"CExLabel"
 			"fieldName"			"Kills"
-			"font"				"FontBold37"
 			"labelText"			"%kills%"
-			"textAlignment"		"east"
 			"xpos"				"0"
 			"ypos"				"0"
-			"zpos"				"3"
 			"wide"				"80"
 			"tall"				"50"
-			"autoResize"		"0"
-			"pinCorner"			"0"
 			"visible"			"0"
 			"enabled"			"0"
 			"fgcolor"			"TanLight"
@@ -1069,10 +920,6 @@
 			"zpos"				"3"
 			"wide"				"80"
 			"tall"				"50"
-			"autoResize"		"0"
-			"pinCorner"			"0"
-			"visible"			"1"
-			"enabled"			"1"
 			"fgcolor"			"TanLight"
 			"pin_to_sibling"	"Kills"
 		}
@@ -1081,36 +928,21 @@
 		{
 			"ControlName"		"CExLabel"
 			"fieldName"			"DeathsLabel"
-			"font"				"FontRegular11"
-			"labelText"			"#TF_ScoreBoard_DeathsLabel"
-			"textAlignment"		"east"
-			"xpos"				"0"
-			"ypos"				"0"
-			"zpos"				"0"
 			"wide"				"0"
-			"tall"				"0"
-			"autoResize"		"0"
-			"pinCorner"			"0"
-			"visible"			"1"
-			"enabled"			"1"
+			"visible"			"0"
+			"enabled"			"0"
 		}
 		"Deaths"
 		{
 			"ControlName"		"CExLabel"
 			"fieldName"			"Deaths"
-			"font"				"FontBold37"
 			"labelText"			"%deaths%"
-			"textAlignment"		"west"
 			"xpos"				"0"
 			"ypos"				"0"
-			"zpos"				"3"
 			"wide"				"80"
 			"tall"				"50"
-			"autoResize"		"0"
-			"pinCorner"			"0"
 			"visible"			"0"
 			"enabled"			"0"
-			"fgcolor"			"TanLight"
 
 			"pin_to_sibling"		"KillsLabel"
 			"pin_corner_to_sibling"	"PIN_TOPLEFT"
@@ -1128,11 +960,6 @@
 			"zpos"				"3"
 			"wide"				"80"
 			"tall"				"50"
-			"autoResize"		"0"
-			"pinCorner"			"0"
-			"visible"			"1"
-			"enabled"			"1"
-			"fgcolor"			"TanLight"
 			"pin_to_sibling"	"Deaths"
 		}
 
@@ -1140,19 +967,9 @@
 		{
 			"ControlName"		"CExLabel"
 			"fieldName"			"gametype"
-			"font"				"ScoreboardVerySmall"
-			"labelText"			"%gametype%"
-			"textAlignment"		"east"
-			"xpos"				"5"
-			"ypos"				"10"
-			"zpos"				"3"
-			"wide"				"585"
-			"tall"				"20"
-			"autoResize"		"0"
-			"pinCorner"			"0"
+			"wide"				"0"
 			"visible"			"0"
 			"enabled"			"0"
-			"fgcolor"			"TanLight"
 		}
 
 		"AssistsLabel"
@@ -1167,10 +984,6 @@
 			"zpos"				"3"
 			"wide"				"50"
 			"tall"				"20"
-			"autoResize"		"0"
-			"pinCorner"			"0"
-			"visible"			"1"
-			"enabled"			"1"
 
 			"pin_to_sibling"		"StatsBG"
 			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
@@ -1187,16 +1000,11 @@
 		{
 			"ControlName"		"CExLabel"
 			"fieldName"			"Assists"
-			"font"				"FontRegular11"
 			"labelText"			"%assists%"
-			"textAlignment"		"west"
 			"xpos"				"35"
 			"ypos"				"0"
-			"zpos"				"3"
 			"wide"				"30"
 			"tall"				"20"
-			"autoResize"		"0"
-			"pinCorner"			"0"
 			"visible"			"0"
 			"enabled"			"0"
 			"pin_to_sibling"		"AssistsLabel"
@@ -1215,10 +1023,7 @@
 			"zpos"				"3"
 			"wide"				"30"
 			"tall"				"20"
-			"autoResize"		"0"
-			"pinCorner"			"0"
-			"visible"			"1"
-			"enabled"			"1"
+
 			"pin_to_sibling"		"Assists"
 			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
 			"pin_to_sibling_corner"	"PIN_TOPRIGHT"
@@ -1241,10 +1046,6 @@
 			"zpos"				"3"
 			"wide"				"60"
 			"tall"				"20"
-			"autoResize"		"0"
-			"pinCorner"			"0"
-			"visible"			"1"
-			"enabled"			"1"
 			
 			"pin_to_sibling"		"AssistsLabel"
 			"pin_corner_to_sibling"	"PIN_BOTTOMRIGHT"
@@ -1265,27 +1066,17 @@
 		{
 			"ControlName"		"CExLabel"
 			"fieldName"			"Destruction"
-			"font"				"FontRegular11"
 			"labelText"			"%destruction%"
-			"textAlignment"		"west"
 			"xpos"				"35"
 			"ypos"				"0"
-			"zpos"				"3"
 			"wide"				"30"
 			"tall"				"20"
-			"autoResize"		"0"
-			"pinCorner"			"0"
 			"visible"			"0"
 			"enabled"			"0"
 			
 			"pin_to_sibling"		"DestructionLabel"
 			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
 			"pin_to_sibling_corner"	"PIN_TOPRIGHT"
-
-			if_mvm
-			{
-				"visible"			"0"
-			}
 		}
 		"Destruction2"
 		{
@@ -1299,10 +1090,6 @@
 			"zpos"				"3"
 			"wide"				"30"
 			"tall"				"20"
-			"autoResize"		"0"
-			"pinCorner"			"0"
-			"visible"			"1"
-			"enabled"			"1"
 
 			"pin_to_sibling"		"Destruction"
 			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
@@ -1326,10 +1113,6 @@
 			"zpos"				"3"
 			"wide"				"50"
 			"tall"				"20"
-			"autoResize"		"0"
-			"pinCorner"			"0"
-			"visible"			"1"
-			"enabled"			"1"
 
 			"pin_to_sibling"		"DestructionLabel"
 			"pin_corner_to_sibling"	"PIN_BOTTOMRIGHT"
@@ -1344,27 +1127,17 @@
 		{
 			"ControlName"		"CExLabel"
 			"fieldName"			"Captures"
-			"font"				"FontRegular11"
 			"labelText"			"%captures%"
-			"textAlignment"		"west"
 			"xpos"				"35"
 			"ypos"				"0"
-			"zpos"				"3"
 			"wide"				"30"
 			"tall"				"20"
-			"autoResize"		"0"
-			"pinCorner"			"0"
 			"visible"			"0"
 			"enabled"			"0"
 
 			"pin_to_sibling"		"CapturesLabel"
 			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
 			"pin_to_sibling_corner"	"PIN_TOPRIGHT"
-
-			if_mvm
-			{
-				"visible"			"0"
-			}
 		}
 		"Captures2"
 		{
@@ -1378,10 +1151,6 @@
 			"zpos"				"3"
 			"wide"				"30"
 			"tall"				"20"
-			"autoResize"		"0"
-			"pinCorner"			"0"
-			"visible"			"1"
-			"enabled"			"1"
 
 			"pin_to_sibling"		"Captures"
 			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
@@ -1405,10 +1174,6 @@
 			"zpos"				"3"
 			"wide"				"50"
 			"tall"				"20"
-			"autoResize"		"0"
-			"pinCorner"			"0"
-			"visible"			"1"
-			"enabled"			"1"
 
 			"pin_to_sibling"		"AssistsLabel"
 			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
@@ -1429,27 +1194,17 @@
 		{
 			"ControlName"		"CExLabel"
 			"fieldName"			"Defenses"
-			"font"				"FontRegular11"
 			"labelText"			"%defenses%"
-			"textAlignment"		"west"
 			"xpos"				"35"
 			"ypos"				"0"
-			"zpos"				"3"
 			"wide"				"30"
 			"tall"				"20"
-			"autoResize"		"0"
-			"pinCorner"			"0"
 			"visible"			"0"
 			"enabled"			"0"
 
 			"pin_to_sibling"		"DefensesLabel"
 			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
 			"pin_to_sibling_corner"	"PIN_TOPRIGHT"
-
-			if_mvm
-			{
-				"visible"	"0"
-			}
 		}
 		"Defenses2"
 		{
@@ -1463,10 +1218,6 @@
 			"zpos"				"3"
 			"wide"				"30"
 			"tall"				"20"
-			"autoResize"		"0"
-			"pinCorner"			"0"
-			"visible"			"1"
-			"enabled"			"1"
 
 			"pin_to_sibling"		"Defenses"
 			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
@@ -1490,10 +1241,6 @@
 			"zpos"				"3"
 			"wide"				"55"
 			"tall"				"20"
-			"autoResize"		"0"
-			"pinCorner"			"0"
-			"visible"			"1"
-			"enabled"			"1"
 
 			"pin_to_sibling"		"DefensesLabel"
 			"pin_corner_to_sibling"	"PIN_BOTTOMRIGHT"
@@ -1508,27 +1255,17 @@
 		{
 			"ControlName"		"CExLabel"
 			"fieldName"			"Domination"
-			"font"				"FontRegular11"
 			"labelText"			"%dominations%"
-			"textAlignment"		"west"
 			"xpos"				"35"
 			"ypos"				"0"
-			"zpos"				"3"
 			"wide"				"30"
 			"tall"				"20"
-			"autoResize"		"0"
-			"pinCorner"			"0"
 			"visible"			"0"
 			"enabled"			"0"
 
 			"pin_to_sibling"		"DominationLabel"
 			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
 			"pin_to_sibling_corner"	"PIN_TOPRIGHT"
-
-			if_mvm
-			{
-				"visible"			"0"
-			}
 		}
 		"Domination2"
 		{
@@ -1542,10 +1279,6 @@
 			"zpos"				"3"
 			"wide"				"30"
 			"tall"				"20"
-			"autoResize"		"0"
-			"pinCorner"			"0"
-			"visible"			"1"
-			"enabled"			"1"
 
 			"pin_to_sibling"		"Domination"
 			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
@@ -1569,10 +1302,6 @@
 			"zpos"				"3"
 			"wide"				"50"
 			"tall"				"20"
-			"autoResize"		"0"
-			"pinCorner"			"0"
-			"visible"			"1"
-			"enabled"			"1"
 
 			"pin_to_sibling"		"DominationLabel"
 			"pin_corner_to_sibling"	"PIN_BOTTOMRIGHT"
@@ -1587,27 +1316,17 @@
 		{
 			"ControlName"		"CExLabel"
 			"fieldName"			"Revenge"
-			"font"				"FontRegular11"
 			"labelText"			"%Revenge%"
-			"textAlignment"		"west"
 			"xpos"				"35"
 			"ypos"				"0"
-			"zpos"				"3"
 			"wide"				"30"
 			"tall"				"20"
-			"autoResize"		"0"
-			"pinCorner"			"0"
 			"visible"			"0"
 			"enabled"			"0"
 
 			"pin_to_sibling"		"RevengeLabel"
 			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
 			"pin_to_sibling_corner"	"PIN_TOPRIGHT"
-
-			if_mvm
-			{
-				"visible"			"0"
-			}
 		}
 		"Revenge2"
 		{
@@ -1621,10 +1340,6 @@
 			"zpos"				"3"
 			"wide"				"30"
 			"tall"				"20"
-			"autoResize"		"0"
-			"pinCorner"			"0"
-			"visible"			"1"
-			"enabled"			"1"
 
 			"pin_to_sibling"		"Revenge"
 			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
@@ -1648,10 +1363,6 @@
 			"zpos"				"3"
 			"wide"				"50"
 			"tall"				"20"
-			"autoResize"		"0"
-			"pinCorner"			"0"
-			"visible"			"1"
-			"enabled"			"1"
 
 			"pin_to_sibling"		"DefensesLabel"
 			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
@@ -1659,14 +1370,7 @@
 
 			if_mvm
 			{
-				"font"			"FontRegular10"
-				"xpos"			"0"
-				"ypos"			"20"
 				"visible"		"0" 
-				
-				"pin_to_sibling"		"AssistsLabel"
-				"pin_corner_to_sibling"	"PIN_BOTTOMRIGHT"
-				"pin_to_sibling_corner"	"PIN_BOTTOMRIGHT"
 			}
 		}
 
@@ -1674,16 +1378,11 @@
 		{
 			"ControlName"		"CExLabel"
 			"fieldName"			"Healing"
-			"font"				"FontRegular11"
 			"labelText"			"%healing%"
-			"textAlignment"		"west"
 			"xpos"				"35"
 			"ypos"				"0"
-			"zpos"				"3"
 			"wide"				"30"
 			"tall"				"20"
-			"autoResize"		"0"
-			"pinCorner"			"0"
 			"visible"			"0"
 			"enabled"			"0"
 
@@ -1703,10 +1402,6 @@
 			"zpos"				"3"
 			"wide"				"30"
 			"tall"				"20"
-			"autoResize"		"0"
-			"pinCorner"			"0"
-			"visible"			"1"
-			"enabled"			"1"
 
 			"pin_to_sibling"		"Healing"
 			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
@@ -1714,7 +1409,6 @@
 
 			if_mvm
 			{
-				"font"		"FontRegular10"
 				"visible"	"0"
 			}
 		}
@@ -1731,10 +1425,6 @@
 			"zpos"				"3"
 			"wide"				"50"
 			"tall"				"20"
-			"autoResize"		"0"
-			"pinCorner"			"0"
-			"visible"			"1"
-			"enabled"			"1"
 
 			"pin_to_sibling"		"HealingLabel"
 			"pin_corner_to_sibling"	"PIN_BOTTOMRIGHT"
@@ -1754,16 +1444,11 @@
 		{
 			"ControlName"		"CExLabel"
 			"fieldName"			"Invuln"
-			"font"				"FontRegular11"
 			"labelText"			"%invulns%"
-			"textAlignment"		"west"
 			"xpos"				"35"
 			"ypos"				"0"
-			"zpos"				"3"
 			"wide"				"30"
 			"tall"				"20"
-			"autoResize"		"0"
-			"pinCorner"			"0"
 			"visible"			"0"
 			"enabled"			"0"
 
@@ -1783,10 +1468,6 @@
 			"zpos"				"3"
 			"wide"				"30"
 			"tall"				"20"
-			"autoResize"		"0"
-			"pinCorner"			"0"
-			"visible"			"1"
-			"enabled"			"1"
 
 			"pin_to_sibling"		"Invuln"
 			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
@@ -1810,10 +1491,6 @@
 			"zpos"				"3"
 			"wide"				"50"
 			"tall"				"20"
-			"autoResize"		"0"
-			"pinCorner"			"0"
-			"visible"			"1"
-			"enabled"			"1"
 
 			"pin_to_sibling"		"InvulnLabel"
 			"pin_corner_to_sibling"	"PIN_BOTTOMRIGHT"
@@ -1834,16 +1511,11 @@
 		{
 			"ControlName"		"CExLabel"
 			"fieldName"			"Teleports"
-			"font"				"FontRegular11"
 			"labelText"			"%teleports%"
-			"textAlignment"		"west"
 			"xpos"				"35"
 			"ypos"				"0"
-			"zpos"				"3"
 			"wide"				"30"
 			"tall"				"20"
-			"autoResize"		"0"
-			"pinCorner"			"0"
 			"visible"			"0"
 			"enabled"			"0"
 
@@ -1863,10 +1535,6 @@
 			"zpos"				"3"
 			"wide"				"30"
 			"tall"				"20"
-			"autoResize"		"0"
-			"pinCorner"			"0"
-			"visible"			"1"
-			"enabled"			"1"
 
 			"pin_to_sibling"		"Teleports"
 			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
@@ -1890,10 +1558,6 @@
 			"zpos"				"3"
 			"wide"				"50"
 			"tall"				"20"
-			"autoResize"		"0"
-			"pinCorner"			"0"
-			"visible"			"1"
-			"enabled"			"1"
 
 			"pin_to_sibling"		"HealingLabel"
 			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
@@ -1915,16 +1579,11 @@
 		{
 			"ControlName"		"CExLabel"
 			"fieldName"			"Headshots"
-			"font"				"FontRegular11"
 			"labelText"			"%headshots%"
-			"textAlignment"		"west"
 			"xpos"				"35"
 			"ypos"				"0"
-			"zpos"				"3"
 			"wide"				"30"
 			"tall"				"20"
-			"autoResize"		"0"
-			"pinCorner"			"0"
 			"visible"			"0"
 			"enabled"			"0"
 
@@ -1944,10 +1603,6 @@
 			"zpos"				"3"
 			"wide"				"30"
 			"tall"				"20"
-			"autoResize"		"0"
-			"pinCorner"			"0"
-			"visible"			"1"
-			"enabled"			"1"
 
 			"pin_to_sibling"		"Headshots"
 			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
@@ -1971,10 +1626,6 @@
 			"zpos"				"3"
 			"wide"				"50"
 			"tall"				"20"
-			"autoResize"		"0"
-			"pinCorner"			"0"
-			"visible"			"1"
-			"enabled"			"1"
 
 			"pin_to_sibling"		"HeadshotsLabel"
 			"pin_corner_to_sibling"	"PIN_BOTTOMRIGHT"
@@ -1995,16 +1646,11 @@
 		{
 			"ControlName"		"CExLabel"
 			"fieldName"			"Backstabs"
-			"font"				"FontRegular11"
 			"labelText"			"%backstabs%"
-			"textAlignment"		"west"
 			"xpos"				"35"
-			"ypos"				"0"
 			"zpos"				"3"
 			"wide"				"30"
 			"tall"				"20"
-			"autoResize"		"0"
-			"pinCorner"			"0"
 			"visible"			"0"
 			"enabled"			"0"
 
@@ -2024,10 +1670,6 @@
 			"zpos"				"3"
 			"wide"				"30"
 			"tall"				"20"
-			"autoResize"		"0"
-			"pinCorner"			"0"
-			"visible"			"1"
-			"enabled"			"1"
 
 			"pin_to_sibling"		"Backstabs"
 			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
@@ -2051,10 +1693,6 @@
 			"zpos"				"3"
 			"wide"				"50"
 			"tall"				"20"
-			"autoResize"		"0"
-			"pinCorner"			"0"
-			"visible"			"1"
-			"enabled"			"1"
 
 			"pin_to_sibling"		"BackstabsLabel"
 			"pin_corner_to_sibling"	"PIN_BOTTOMRIGHT"
@@ -2075,16 +1713,11 @@
 		{
 			"ControlName"		"CExLabel"
 			"fieldName"			"Bonus"
-			"font"				"FontRegular11"
 			"labelText"			"%bonus%"
-			"textAlignment"		"west"
 			"xpos"				"35"
 			"ypos"				"0"
-			"zpos"				"3"
 			"wide"				"30"
 			"tall"				"20"
-			"autoResize"		"0"
-			"pinCorner"			"0"
 			"visible"			"0"
 			"enabled"			"0"
 
@@ -2104,10 +1737,6 @@
 			"zpos"				"3"
 			"wide"				"30"
 			"tall"				"20"
-			"autoResize"		"0"
-			"pinCorner"			"0"
-			"visible"			"1"
-			"enabled"			"1"
 
 			"pin_to_sibling"		"Bonus"
 			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
@@ -2131,10 +1760,6 @@
 			"zpos"				"3"
 			"wide"				"50"
 			"tall"				"20"
-			"autoResize"		"0"
-			"pinCorner"			"0"
-			"visible"			"1"
-			"enabled"			"1"
 
 			"pin_to_sibling"		"HeadshotsLabel"
 			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
@@ -2156,16 +1781,11 @@
 		{
 			"ControlName"		"CExLabel"
 			"fieldName"			"Support"
-			"font"				"FontRegular11"
 			"labelText"			"%support%"
-			"textAlignment"		"west"
 			"xpos"				"35"
 			"ypos"				"0"
-			"zpos"				"3"
 			"wide"				"30"
 			"tall"				"20"
-			"autoResize"		"0"
-			"pinCorner"			"0"
 			"visible"			"0"
 			"enabled"			"0"
 
@@ -2185,10 +1805,6 @@
 			"zpos"				"3"
 			"wide"				"30"
 			"tall"				"20"
-			"autoResize"		"0"
-			"pinCorner"			"0"
-			"visible"			"1"
-			"enabled"			"1"
 
 			"pin_to_sibling"		"Support"
 			"pin_corner_to_sibling"	"PIN_TOPRIGHT"
@@ -2196,7 +1812,6 @@
 
 			if_mvm
 			{
-				"font"		"FontRegular10"
 				"visible"	"0"
 			}
 		}
@@ -2213,10 +1828,6 @@
 			"zpos"				"3"
 			"wide"				"50"
 			"tall"				"20"
-			"autoResize"		"0"
-			"pinCorner"			"0"
-			"visible"			"1"
-			"enabled"			"1"
 
 			"pin_to_sibling"		"SupportLabel"
 			"pin_corner_to_sibling"	"PIN_BOTTOMRIGHT"
@@ -2224,8 +1835,6 @@
 
 			if_mvm
 			{
-				"font"		"FontRegular10"
-				"ypos"		"20"
 				"visible"	"0"
 			}
 		}
@@ -2233,16 +1842,11 @@
 		{
 			"ControlName"		"CExLabel"
 			"fieldName"			"Damage"
-			"font"				"FontRegular11"
 			"labelText"			"%damage%"
-			"textAlignment"		"west"
 			"xpos"				"35"
 			"ypos"				"0"
-			"zpos"				"3"
 			"wide"				"30"
 			"tall"				"20"
-			"autoResize"		"0"
-			"pinCorner"			"0"
 			"visible"			"0"
 			"enabled"			"0"
 
@@ -2262,18 +1866,10 @@
 			"zpos"				"3"
 			"wide"				"30"
 			"tall"				"20"
-			"autoResize"		"0"
-			"pinCorner"			"0"
-			"visible"			"1"
-			"enabled"			"1"
-
 			"pin_to_sibling"		"Damage"
-			"pin_corner_to_sibling"		"PIN_TOPRIGHT"
-			"pin_to_sibling_corner"		"PIN_TOPRIGHT"
 
 			if_mvm
 			{
-				"font"		"FontRegular10"
 				"visible"	"0"
 			}
 		}
@@ -2289,8 +1885,6 @@
 			"zpos"				"3"
 			"wide"				"50"
 			"tall"				"20"
-			"autoResize"		"0"
-			"pinCorner"			"0"
 			"visible"			"0"
 			"enabled"			"0"
 			"fgcolor"			"DisguiseMenuIconBlue"
@@ -2317,8 +1911,6 @@
 			"zpos"				"3"
 			"wide"				"50"
 			"tall"				"20"
-			"autoResize"		"0"
-			"pinCorner"			"0"
 			"visible"			"0"
 			"enabled"			"0"
 			"fgcolor"			"DisguiseMenuIconBlue"

--- a/resource/ui/scoreboard.res
+++ b/resource/ui/scoreboard.res
@@ -23,36 +23,12 @@
 		"medal_width_minmode"	 "0"
 	}
 
-	"BlueLine"
-	{
-		"ControlName"		"EditablePanel"
-		"fieldName"			"BlueLine"
-		"xpos"				"0"
-		"ypos"				"0"
-		"zpos"				"1"
-		"wide"				"2"
-		"tall"				"35"
-		"PaintBackgroundType"	"0"
-		"paintbackground"		"1"
-		"bgcolor_override"		"BlueTeam"
-
-		"pin_to_sibling"		"BlueBG"
-		"pin_corner_to_sibling"	"PIN_TOPRIGHT"
-		"pin_to_sibling_corner"	"PIN_TOPRIGHT"
-
-		if_mvm
-		{
-			"visible"			"0"
-		}
-	}
-
 	"BlueBG"
 	{
 		"ControlName"		"EditablePanel"
 		"fieldName"			"BlueBG"
 		"xpos"				"c-291"
-		"ypos"				"100"
-		"zpos"				"-1"
+		"ypos"				"83"
 		"wide"				"290"
 		"tall"				"35"
 		"bgcolor_override"	"HudBlack"
@@ -60,33 +36,10 @@
 		
 		if_mvm
  		{
-			"ypos"				"100"	// This is needed for the 32-player scoreboard customization available in the HUD Editor.
  			"visible"			"0"
  		}
 	}
-	"BluePlayerBG"
-	{
-		"ControlName"		"EditablePanel"
-		"fieldName"			"BluePlayerBG"
-		"xpos"				"0"
-		"ypos"				"2"
-		"zpos"				"2"
-		"wide"				"290"
-		"wide_minmode"		"0"
-		"tall"				"210"
-		"bgcolor_override"	"25 25 25 200"
-		"PaintBackgroundType"	"2"
-
-		"pin_to_sibling"		"ServerBackground"
-		"pin_corner_to_sibling"	"PIN_TOPLEFT"
-		"pin_to_sibling_corner"	"PIN_BOTTOMLEFT"
-
-		if_mvm
- 		{
- 			"visible"			"0"
- 		}
-	}
-
+	
 	"BlueTeamName"
 	{
 		"ControlName"		"CExLabel"
@@ -94,52 +47,16 @@
 		"font"				"FontBold22"
 		"labelText"			"%blueteamname%"
 		"textAlignment"		"west"
-		"xpos"				"0"
+		"xpos"				"-6"
 		"ypos"				"0"
 		"wide"				"250"
 		"tall"				"22"
 		"fgcolor"			"BlueTeam"
-		"TextInsetX"		"15"
-
 		"pin_to_sibling"		"BlueBG"
 
 		if_mvm
 		{
 			"visible"			"0"
-		}
-	}
-
-	"BlueTeamScore"
-	{
-		"ControlName"		"CExLabel"
-		"fieldName"			"BlueTeamScore"
-		"font"				"FontBold37"
-		"labelText"			"%blueteamscore%"
-		"textAlignment"		"east"
-		"xpos"				"0"
-		"ypos"				"0"
-		"zpos"				"4"
-		"wide"				"80"
-		"tall"				"35"
-		"fgcolor"			"BlueTeam"
-		"TextInsetX"		"20"
-
-		"pin_to_sibling"		"BlueBG"
-		"pin_corner_to_sibling"	"PIN_TOPRIGHT"
-		"pin_to_sibling_corner"	"PIN_TOPRIGHT"
-
-		if_mvm
-		{
-			"font"				"FontRegular10"
-			"textAlignment"		"west"
-			"TextInsetX"		"0"
-			"xpos"				"0"
-			"ypos"				"-100"
-			"zpos"				"11"
-			"wide"				"44"
-			"tall"				"20"
-			"fgcolor"			"DisguiseMenuIconBlue"
-			"pin_to_sibling"		"StatsBG"
 		}
 	}
 
@@ -155,7 +72,6 @@
 		"wide"				"210"
 		"tall"				"12"
 		"fgcolor"			"BlueTeam"
-		"TextInsetX"		"15"
 
 		"pin_to_sibling"		"BlueTeamName"
 		"pin_corner_to_sibling"	"PIN_TOPLEFT"
@@ -167,20 +83,49 @@
 		}
 	}
 
-	"RedLine"
+	"BlueTeamScore"
+	{
+		"ControlName"		"CExLabel"
+		"fieldName"			"BlueTeamScore"
+		"font"				"FontBold37"
+		"labelText"			"%blueteamscore%"
+		"textAlignment"		"east"
+		"xpos"				"-10"
+		"ypos"				"0"
+		"wide"				"80"
+		"tall"				"35"
+		"fgcolor"			"BlueTeam"
+
+		"pin_to_sibling"		"BlueBG"
+		"pin_corner_to_sibling"	"PIN_TOPRIGHT"
+		"pin_to_sibling_corner"	"PIN_TOPRIGHT"
+
+		if_mvm
+		{
+			"font"				"FontRegular10"
+			"textAlignment"		"west"
+			"ypos"				"-100"
+			"zpos"				"1"
+			"wide"				"34"
+			"tall"				"20"
+			"fgcolor"			"DisguiseMenuIconBlue"
+			"pin_to_sibling"		"StatsBG"
+		}
+	}
+
+	"BlueLine"
 	{
 		"ControlName"		"EditablePanel"
-		"fieldName"			"RedLine"
+		"fieldName"			"BlueLine"
 		"xpos"				"0"
 		"ypos"				"0"
-		"zpos"				"1"
-		"wide"				"2"
+		"wide"				"3"
 		"tall"				"35"
-		"PaintBackgroundType"	"0"
-		"paintbackground"		"1"
-		"bgcolor_override"		"RedTeam"
+		"bgcolor_override"		"BlueTeam"
 
-		"pin_to_sibling"		"RedBG"
+		"pin_to_sibling"		"BlueBG"
+		"pin_corner_to_sibling"	"PIN_TOPRIGHT"
+		"pin_to_sibling_corner"	"PIN_TOPRIGHT"
 
 		if_mvm
 		{
@@ -193,8 +138,7 @@
 		"ControlName"		"EditablePanel"
 		"fieldName"			"RedBG"
 		"xpos"				"2"
-		"ypos"				"0"
-		"zpos"				"-1"
+		"ypos"				"0"	
 		"wide"				"290"
 		"tall"				"35"
 		"bgcolor_override"	"HudBlack"
@@ -209,29 +153,7 @@
 			"visible"			"0"
 		}
 	}
-	"RedPlayerBG"
-	{
-		"ControlName"		"EditablePanel"
-		"fieldName"			"RedPlayerBG"
-		"xpos"				"0"
-		"ypos"				"2"
-		"zpos"				"2"
-		"wide"				"290"
-		"wide_minmode"		"0"
-		"tall"				"210"
-		"bgcolor_override"	"25 25 25 200"
-		"PaintBackgroundType"	"2"
-
-		"pin_to_sibling"		"ServerTimeBackground"
-		"pin_corner_to_sibling"	"PIN_TOPLEFT"
-		"pin_to_sibling_corner"	"PIN_BOTTOMLEFT"
-
-		if_mvm
-		{
-			"visible"			"0"
-		}
-	}
-
+	
 	"RedTeamName"
 	{
 		"ControlName"		"CExLabel"
@@ -239,39 +161,15 @@
 		"font"				"FontBold22"
 		"labelText"			"%redteamname%"
 		"textAlignment"		"east"
-		"xpos"				"0"
+		"xpos"				"-6"
 		"ypos"				"0"
 		"wide"				"250"
 		"tall"				"22"
 		"fgcolor"			"RedTeam"
-		"TextInsetX"		"15"
 
 		"pin_to_sibling"		"RedBG"
 		"pin_corner_to_sibling"	"PIN_TOPRIGHT"
 		"pin_to_sibling_corner"	"PIN_TOPRIGHT"
-
-		if_mvm
-		{
-			"visible"			"0"
-		}
-	}
-
-	"RedTeamScore"
-	{
-		"ControlName"		"CExLabel"
-		"fieldName"			"RedTeamScore"
-		"font"				"FontBold37"
-		"labelText"			"%redteamscore%"
-		"textAlignment"		"west"
-		"xpos"				"0"
-		"ypos"				"0"
-		"zpos"				"4"
-		"wide"				"80"
-		"tall"				"35"
-		"fgcolor"			"RedTeam"
-		"TextInsetX"		"23"
-
-		"pin_to_sibling"		"RedBG"
 
 		if_mvm
 		{
@@ -291,7 +189,6 @@
 		"wide"				"210"
 		"tall"				"12"
 		"fgcolor"			"RedTeam"
-		"TextInsetX"		"20"
 
 		"pin_to_sibling"		"RedTeamName"
 		"pin_corner_to_sibling"	"PIN_TOPRIGHT"
@@ -303,16 +200,138 @@
 		}
 	}
 
+	"RedLine"
+	{
+		"ControlName"		"EditablePanel"
+		"fieldName"			"RedLine"
+		"xpos"				"0"
+		"ypos"				"0"
+		"wide"				"3"
+		"tall"				"35"
+		"bgcolor_override"		"RedTeam"
+		"pin_to_sibling"		"RedBG"
+
+		if_mvm
+		{
+			"visible"			"0"
+		}
+	}
+
+	"RedTeamScore"
+	{
+		"ControlName"		"CExLabel"
+		"fieldName"			"RedTeamScore"
+		"font"				"FontBold37"
+		"labelText"			"%redteamscore%"
+		"textAlignment"		"west"
+		"xpos"				"-10"
+		"ypos"				"0"
+		"wide"				"80"
+		"tall"				"35"
+		"fgcolor"			"RedTeam"
+		"pin_to_sibling"		"RedBG"
+
+		if_mvm
+		{
+			"visible"			"0"
+		}
+	}
+
+	"BluePlayerBG"
+	{
+		"ControlName"		"EditablePanel"
+		"fieldName"			"BluePlayerBG"
+		"xpos"				"0"
+		"ypos"				"2"
+		"wide"				"290"
+		"wide_minmode"		"0"
+		"tall"				"210"
+		"bgcolor_override"	"HudBlack"
+		"PaintBackgroundType"	"2"
+
+		"pin_to_sibling"		"ServerBackground"
+		"pin_corner_to_sibling"	"PIN_TOPLEFT"
+		"pin_to_sibling_corner"	"PIN_BOTTOMLEFT"
+
+		if_mvm
+ 		{
+ 			"visible"			"0"
+ 		}
+	}
+	
+	"BluePlayerList"
+	{
+		"ControlName"		"SectionedListPanel"
+		"fieldName"			"BluePlayerList"
+		"xpos"				"c-290"
+		"ypos"				"c-105"
+		"zpos"				"1"
+		"wide"				"288"
+		"tall"				"204"
+		"wide_minmode"		"0"
+		"tabPosition"		"0"
+		"autoresize"		"3"
+		"linespacing"		"16"
+		"fgcolor"			"BlueTeamSolid"
+
+		if_mvm
+		{
+			"visible"			"0"
+		}
+	}
+	
+	"RedPlayerBG"
+	{
+		"ControlName"		"EditablePanel"
+		"fieldName"			"RedPlayerBG"
+		"xpos"				"0"
+		"ypos"				"2"
+		"wide"				"290"
+		"wide_minmode"		"0"
+		"tall"				"210"
+		"bgcolor_override"	"HudBlack"
+		"PaintBackgroundType"	"2"
+
+		"pin_to_sibling"		"ServerTimeBackground"
+		"pin_corner_to_sibling"	"PIN_TOPLEFT"
+		"pin_to_sibling_corner"	"PIN_BOTTOMLEFT"
+
+		if_mvm
+		{
+			"visible"			"0"
+		}
+	}
+
+	"RedPlayerList"
+	{
+		"ControlName"		"SectionedListPanel"
+		"fieldName"			"RedPlayerList"
+		"xpos"				"c+2"
+		"ypos"				"c-105"
+		"zpos"				"1"
+		"wide"				"288"
+		"tall"				"204"
+		"wide_minmode"		"0"
+		"tabPosition"		"0"
+		"autoresize"		"3"
+		"linespacing"		"16"
+		"textcolor"			"HUDRedTeamSolid"
+
+		if_mvm
+		{
+			"visible"			"0"
+		}
+	}
+	
 	"ServerBackground"
 	{
 		"ControlName"		"EditablePanel"
 		"fieldName"			"ServerBackground"
 		"xpos"				"0"
 		"ypos"				"2"
-		"zpos"				"-1"
 		"wide"				"290"
 		"tall"				"11"
-		"bgcolor_override"	"25 25 25 200"
+		"bgcolor_override"	"HudBlack"
 		"PaintBackgroundType"	"2"
 
 		"pin_to_sibling"		"BlueBG"
@@ -357,10 +376,9 @@
 		"fieldName"			"ServerTimeBackground"
 		"xpos"				"0"
 		"ypos"				"2"
-		"zpos"				"-1"
 		"wide"				"290"
 		"tall"				"11"
-		"bgcolor_override"	"25 25 25 200"
+		"bgcolor_override"	"HudBlack"
 		"PaintBackgroundType"	"2"
 
 		"pin_to_sibling"		"RedBG"
@@ -382,55 +400,12 @@
 		"textAlignment"		"east"
 		"xpos"				"-5"
 		"ypos"				"0"
-		"zpos"				"2"
 		"wide"				"290"
 		"tall"				"11"
 
 		"pin_to_sibling"		"ServerTimeBackground"
 		"pin_corner_to_sibling"	"PIN_TOPRIGHT"
 		"pin_to_sibling_corner"	"PIN_TOPRIGHT"
-
-		if_mvm
-		{
-			"visible"			"0"
-		}
-	}
-
-	"BluePlayerList"
-	{
-		"ControlName"		"SectionedListPanel"
-		"fieldName"			"BluePlayerList"
-		"xpos"				"c-290"
-		"ypos"				"c-88"
-		"zpos"				"20"
-		"wide"				"288"
-		"tall"				"204"
-		"wide_minmode"		"0"
-		"tabPosition"		"0"
-		"autoresize"		"3"
-		"linespacing"		"16"
-		"fgcolor"			"BlueTeamSolid"
-
-		if_mvm
-		{
-			"visible"			"0"
-		}
-	}
-
-	"RedPlayerList"
-	{
-		"ControlName"		"SectionedListPanel"
-		"fieldName"			"RedPlayerList"
-		"xpos"				"c+2"
-		"ypos"				"c-88"
-		"zpos"				"20"
-		"wide"				"288"
-		"tall"				"204"
-		"wide_minmode"		"0"
-		"tabPosition"		"0"
-		"autoresize"		"3"
-		"linespacing"		"16"
-		"textcolor"			"HUDRedTeamSolid"
 
 		if_mvm
 		{
@@ -448,7 +423,6 @@
 		"wrap"				"1"
 		"xpos"				"-2"
 		"ypos"				"1"
-		"zpos"				"4"
 		"wide"				"370"
 		"wide_minmode"		"0"
 		"tall"				"22"
@@ -472,7 +446,7 @@
 		"ypos"				"2"
 		"wide"				"582"
 		"tall"				"50"
-		"bgcolor_override"	"25 25 25 200"
+		"bgcolor_override"	"HudBlack"
 		"PaintBackgroundType"	"2"
 
 		"pin_to_sibling"		"BluePlayerBG"
@@ -501,7 +475,6 @@
 		"textAlignment"		"north-west"
 		"xpos"				"-2"
 		"ypos"				"-72"
-		"zpos"				"4"
 		"wide"				"577"
 		"wide_minmode"		"0"
 		"tall"				"20"
@@ -519,7 +492,6 @@
 		"fieldName"			"ClassImage"
 		"xpos"				"0"
 		"ypos"				"-5"
-		"zpos"				"3"
 		"wide"				"45"
 		"tall"				"45"
 		"image"				"../hud/class_scoutred"
@@ -541,7 +513,6 @@
 		"fieldName"			"classmodelpanel"
 		"xpos"				"0"
 		"ypos"				"r200"
-		"zpos"				"2"
 		"wide"				"150"
 		"tall"				"200"
 		"fov"				"23"
@@ -581,7 +552,6 @@
 		"visible"			"0"
 		"enabled"			"0"
 	}
-
 	"ServerLabelNew"
 	{
 		"ControlName"		"CExLabel"
@@ -590,6 +560,7 @@
 		"visible"			"0"
 		"enabled"			"0"
 	}
+
 	"MapName"
 	{
 		"ControlName"		"CExLabel"
@@ -599,7 +570,6 @@
 		"textAlignment"		"north-east"
 		"xpos"				"-2"
 		"ypos"				"1"
-		"zpos"				"5"
 		"wide"				"210"
 		"tall"				"15"
 		"allcaps"			"1"
@@ -1570,7 +1540,6 @@
 		"fieldName"			"MvMScoreboard"
 		"xpos"				"0"
 		"ypos"				"0"
-		"zpos"				"10"
 		"wide"				"f0"
 		"tall"				"480"
 		"visible"			"0"

--- a/resource/ui/scoreboard.res
+++ b/resource/ui/scoreboard.res
@@ -345,13 +345,13 @@
 		"tall"				"11"
 
 		"pin_to_sibling"		"ServerBackground"
-		"pin_corner_to_sibling"	"PIN_TOPLEFT"
-		"pin_to_sibling_corner"	"PIN_TOPLEFT"
 
 		if_mvm
 		{
 			"font"				"FontRegular10"
-			"ypos"				"2"
+			"xpos"				"c-270"
+			"ypos"				"78"
+			"pin_to_sibling"	""
 		}
 	}
 	"ServerTimeBackground"
@@ -452,7 +452,7 @@
 		"zpos"				"4"
 		"wide"				"577"
 		"wide_minmode"		"0"
-		"tall"				"15"
+		"tall"				"11"
 
 		"pin_to_sibling"		"StatsBG"
 		"pin_corner_to_sibling"	"PIN_TOPLEFT"
@@ -460,7 +460,7 @@
 
 		if_mvm
 		{
-			"xpos"				"277"
+			"xpos"				"275"
 		    "wide"				"544"
 		}
 	}
@@ -484,7 +484,8 @@
 
 		if_mvm
 		{
-			"ypos"				"167"
+			"xpos"				"4"
+			"ypos"				"166"
 			"wide"				"270"
 			"tall"				"132"
 			"pin_to_sibling"		"mapname"
@@ -614,14 +615,11 @@
 
 		if_mvm
 		{
-			"xpos"				"0"
-			"ypos"				"0"
-			"wide"				"545"
+			"xpos"				"c-279"
+			"ypos"				"64"
+			"wide"				"550"
 			"textAlignment"		"east"
-
-			"pin_to_sibling"		"ServerLabel"
-			"pin_corner_to_sibling"	"PIN_BOTTOMLEFT"
-			"pin_to_sibling_corner"	"PIN_TOPLEFT"
+			"pin_to_sibling"		""
 		}
 	}
 	"HorizontalLine"
@@ -1931,13 +1929,12 @@
 	{
 		"ControlName"		"CTFHudMannVsMachineScoreboard"
 		"fieldName"			"MvMScoreboard"
-		"xpos"				"c-266"
+		"xpos"				"0"
 		"ypos"				"0"
 		"zpos"				"10"
 		"wide"				"f0"
 		"tall"				"480"
 		"visible"			"0"
-		"enabled"			"1"
 		"verbose"			"1"
 
 		if_mvm


### PR DESCRIPTION
The main goal of this patch is mostly light touches while trying to debloat scoreboard.res
Mainly this meant cleaning up dead panels and default key/values (initial commit)
Later removed the extra labels in local player stats panel, it did not seem to affect anything when I played on a valve server.

## MVM Loss label
Too many `pin_to_sibling` dependencies seemingly causing inconsistent positioning of the stats labels even when on the same aspect ratio (vgui coordinate system moment)
`pin_to_sibling` in general seems to make the coordinate system round differently. Moving the sibling or moving other panels (??) can sometimes cause a pixel or two offset for no reason.

It (should) now move approx 1-3 pixels now, instead of 10s of pixels

|  | 2560 x 1440 (16:9) | 1920 x 1080 (16:9) |
|--|--|--|
| Before | ![](https://cdn.discordapp.com/attachments/991465089544761427/1324319184246804573/image.png?ex=6777b7da&is=6776665a&hm=b764c1272ea4ee6f53bfa923a801b70c5448ba85886e1bd42329b62d0943a89c&) | ![](https://i.imgur.com/w4g5FZ4.png)https://i.imgur.com/w4g5FZ4.jpeg |
| | ![](https://i.imgur.com/fhvpJkG.png)https://i.imgur.com/fhvpJkG.png |  |
| After| ![](https://cdn.discordapp.com/attachments/991465089544761427/1324314451549225001/image.png?ex=6777b371&is=677661f1&hm=9263fbe23a21af75e1f68e16c2199361bc69962122b3e182314cdd5c8377853b&) | ![](https://i.imgur.com/YUOfYgu.png)https://i.imgur.com/YUOfYgu.png |
| | ![](https://imgur.com/6Scd3id.png)https://i.imgur.com/6Scd3id.png | ![](https://media.discordapp.net/attachments/991465089544761427/1324323035427115008/image.png?ex=6777bb70&is=677669f0&hm=5aee051ad573fb7549170dfd15f6aad4ecccf6f4ed088a2eb198d2da5c861592&=&format=webp&quality=lossless) https://i.imgur.com/JaqgrQo.png |

### After (continued)
1440:1080
![](https://i.imgur.com/7Fd6UeS.png)https://i.imgur.com/7Fd6UeS.png

2560x1080
![](https://i.imgur.com/39SqnTW.png)https://i.imgur.com/39SqnTW.png

## Drawing Board
Reduced to two panels removed unused key/values
Added mvm support
Improved coverage while maintaining class model mouse input

### Before
|  | 2560 x 1440 (16:9) |
|--|--|
| Before (Stock) | ![](https://i.imgur.com/8AU9Bxx.png)https://i.imgur.com/8AU9Bxx.png |  |
| Before (MVM) | ![](https://i.imgur.com/iZkX0xl.png)https://i.imgur.com/iZkX0xl.png | 

### After 
___
|  | 2560 x 1440 (16:9) | 1920 x 1080 (16:9) |
|--|--|--|
| After (Stock)| ![](https://i.imgur.com/IM7Lq38.png)https://i.imgur.com/IM7Lq38.png | ![](https://i.imgur.com/R27E6p4.png)https://i.imgur.com/R27E6p4.png
| After (MVM)| ![](https://i.imgur.com/hYtTvY8.png)https://i.imgur.com/hYtTvY8.png | ![](https://i.imgur.com/D3tAJ0k.png)https://i.imgur.com/D3tAJ0k.png|

|  | 1440 x 1080 (4:3) | 2560 x 1080 (16:9) |
|--|--|--|
| After (Stock) | ![](https://i.imgur.com/AvrGYuO.png)https://i.imgur.com/AvrGYuO.png | ![](https://i.imgur.com/K0tDLt7.png)https://i.imgur.com/K0tDLt7.png |
| After (MVM) | ![](https://i.imgur.com/g46hMW2.png)https://i.imgur.com/g46hMW2.png | ![](https://i.imgur.com/TLGkBMS.png)https://i.imgur.com/TLGkBMS.png |


## BG Panel Color Consistency + Map Label
BG Panels weren't the same color it was mostly more noticeable in darker areas

Map Label widened and moved down as it didn't always line up nicely with the damage label or that label would have to be really far from the other stats labels.

**Before**
![](https://imgur.com/bYiSdTj.png)**After**
![](https://i.imgur.com/hLdTqHZ.png)

## Team-Colored Lines Widened
 > [!NOTE] 
 > RoundedCorner did not work

**Before**
![](https://cdn.discordapp.com/attachments/991465089544761427/1324282194335629342/image.png?ex=67779567&is=677643e7&hm=614bf6d411a6fff51c963529e3a1e8a9919d64477e8ea830db2161054cf1e046&)**After**
![](https://cdn.discordapp.com/attachments/991465089544761427/1324283171998531585/image.png?ex=67779650&is=677644d0&hm=a80231652b94c04856644f001e355dad965e88c3be498ed5359389ad7d13a3c2&)
## Stats BG Widened
**Before**
![](https://i.imgur.com/9KLE7s8.png)
https://i.imgur.com/9KLE7s8.png
**After**
![](
https://i.imgur.com/Z954ATl.png)
https://i.imgur.com/Z954ATl.png

## Class image moved to bottom left
Now identical to the one in hudplayerclass
![image](https://github.com/user-attachments/assets/c9edf875-ae47-43b9-84ce-774881e438e8)
