### PR TITLE
Add support for cp_cowerhouse

### DIFF
--- a/resource/ui/cp_powerhouse_event_hud.res
+++ b/resource/ui/cp_powerhouse_event_hud.res
@@ -1,0 +1,74 @@
+#base "hudobjectiveplayerdestruction.res"
+
+"resource/ui/cp_powerhouse_event_hud.res"
+{
+	"CountdownContainer"
+	{
+
+
+		"Background"
+		{
+			"xpos" "c"
+			"ypos" "c"
+			"wide" "88"
+			"tall" "44"
+		}
+		
+		"BackgroundColor"
+		{
+			"bgcolor_override"	"0 0 0 210"
+		}
+		
+		"CountdownImage"
+		{
+			"image" "../hud/powerhouse_event_hud_icon_locked"
+			"xpos" "c14"
+			"ypos" "c-15"
+			"wide" "80"
+			"tall" "40"
+		}
+		"CountdownLabelTime"
+		{
+			"xpos" "c36"
+			"ypos" "c-6"
+			"wide" "48"
+			"tall" "24"
+			"font" "HudFontMediumSmallBold"
+		}
+		"CountdownLabelTimeTimeShadow"
+		{
+			"xpos" "c-97"
+			"ypos" "c-27"
+			"wide" "48"
+			"tall" "24"
+			"font" "HudFontMediumSmallBold"
+		}
+	}
+	"ObjectiveStatusRobotDestruction"
+	{
+		"enabled" "0"
+		"visible" "0"
+	}
+	"PlayingTo"
+	{
+		"enabled" "0"
+		"visible" "0"
+	}
+	"PlayingToBG"
+	{
+		"enabled" "0"
+		"visible" "0"
+	}
+	"CarriedContainer"
+	{
+		"enabled" "0"
+		"visible" "0"
+	}
+	"ScoreContainer"
+	{
+		"enabled" "0"
+		"visible" "0"
+	}
+}
+
+//contributed by aaron 'aar' pearson, aarmastah.xyz

--- a/resource/ui/cp_powerhouse_event_hud.res
+++ b/resource/ui/cp_powerhouse_event_hud.res
@@ -2,14 +2,38 @@
 
 "resource/ui/cp_powerhouse_event_hud.res"
 {
+	"ObjectiveStatusRobotDestruction"
+	{
+		"enabled" "0"
+		"visible" "0"
+	}
+	"PlayingTo"
+	{
+		"enabled" "0"
+		"visible" "0"
+	}
+	"PlayingToBG"
+	{
+		"enabled" "0"
+		"visible" "0"
+	}
+	"CarriedContainer"
+	{
+		"enabled" "0"
+		"visible" "0"
+	}
+	"ScoreContainer"
+	{
+		"enabled" "0"
+		"visible" "0"
+	}
 	"CountdownContainer"
 	{
 
-
 		"Background"
 		{
-			"xpos" "c"
-			"ypos" "c"
+			"xpos" "c0"
+			"ypos" "c0"
 			"wide" "88"
 			"tall" "44"
 		}
@@ -43,31 +67,6 @@
 			"tall" "24"
 			"font" "HudFontMediumSmallBold"
 		}
-	}
-	"ObjectiveStatusRobotDestruction"
-	{
-		"enabled" "0"
-		"visible" "0"
-	}
-	"PlayingTo"
-	{
-		"enabled" "0"
-		"visible" "0"
-	}
-	"PlayingToBG"
-	{
-		"enabled" "0"
-		"visible" "0"
-	}
-	"CarriedContainer"
-	{
-		"enabled" "0"
-		"visible" "0"
-	}
-	"ScoreContainer"
-	{
-		"enabled" "0"
-		"visible" "0"
 	}
 }
 


### PR DESCRIPTION
The new Scream Fortress 2025 map Cowerhouse utilizes a custom HUD file. Currently, it does not display correctly in FlawHUD:

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/d6161b18-648e-495d-b6f5-caba3d998346" />

This PR adds proper support for the map in FlawHUD.

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/d99b6228-f295-4696-aec5-00add1f9c8db" />
